### PR TITLE
OAuth2 bearer auth header regex

### DIFF
--- a/oauth2/src/main/scala/protections.scala
+++ b/oauth2/src/main/scala/protections.scala
@@ -69,7 +69,7 @@ case class BearerToken(value: String) extends AccessToken
 
 /** Represents Bearer auth. */
 trait BearerAuth extends AuthScheme {
-  val defaultBearerHeader = """Bearer ([\w|:|\/|.|%|-]+)""".r
+  val defaultBearerHeader = """Bearer ([\w\d!#$%&'\(\)\*+\-\.\/:<=>?@\[\]^_`{|}~\\,;]+)""".r
   def header = defaultBearerHeader
 
   object BearerHeader {


### PR DESCRIPTION
While playing around with the new oauth2 stuff (I know, it's not released yet), I ran into a problem with my Bearer token not being recognized in Protection. It was because it actually had a "$" in it. I was using bcrypt to generate the hash. It does that sometimes. So I looked up the rfc, and it should allow it. Then I fixed.

Fixed Bearer Auth header regex to follow the rfc at http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-03#section-2.1
