### PR TITLE
Add UTF-8 support to unfiltered-scalate

### DIFF
--- a/scalate/src/main/scala/scalate.scala
+++ b/scalate/src/main/scala/scalate.scala
@@ -36,6 +36,7 @@ case class Scalate[A, B](request: HttpRequest[A], template: String, attributes:(
   ) extends Responder[B]{
 
   def respond(res: HttpResponse[B]) {
+    res.setContentType("text/html;charset=UTF-8")
     val writer = res.getWriter()
     try {
       val scalateTemplate = engine.load(template, bindings)


### PR DESCRIPTION
I found that we cannot use UTF-8 string with unfiltered scalate.
I feel this very inconvenience, because my main language is Japanese.

I created a unfiltered-scalate patch to support UTF-8.
