### PR TITLE
support gzip encoding as a library response function

### DIFF
--- a/library/src/main/scala/response/streams.scala
+++ b/library/src/main/scala/response/streams.scala
@@ -1,15 +1,35 @@
 package unfiltered.response
 
 import java.io.OutputStream
+import java.util.zip.{GZIPOutputStream => GZOS}
+
+object Stream {
+  def apply[S <: OutputStream](os: S)(op: S => Unit) {
+    try { op(os) }
+    finally { os.close() }
+  }
+}
 
 trait ResponseStreamer extends Responder[Any] {
   def respond(res: HttpResponse[Any]) {
-    val os = res.getOutputStream()
-    try { stream(os) }
-    finally { os.close() }
+    Stream(res.getOutputStream()) { stream }
   }
   def stream(os: OutputStream): Unit
 }
 case class ResponseBytes(content: Array[Byte]) extends ResponseStreamer {
   def stream(os: OutputStream) { os.write(content) }
+}
+
+trait FilteredStreamer[S <: OutputStream] extends Responder[Any] {
+  def respond(res: HttpResponse[Any]) {
+    Stream(filter(res.getOutputStream())) { stream }
+  }
+  def filter(os: OutputStream): S
+  def stream(os: S): Unit
+}
+case class GZip(content: Array[Byte]) extends FilteredStreamer[GZOS] {
+  def filter(os: OutputStream) = new GZOS(os)
+  def stream(os: GZOS) {
+    os.write(content)
+  }
 }


### PR DESCRIPTION
So I know I have r+w to the main repo, but as I haven't pushed directly to it yet I didn't want to impose. I'm proposing the addition of a GZip response function per the exchange on the group. The stream closing has been cleaned up plus a couple refactorings to keep it tidy. If it looks good I'll go ahead and merge, so as to break the ice ;-).
