### PR TITLE
convenient extractors for Accept-Encoding

### DIFF
--- a/library/src/main/scala/request/decodes.scala
+++ b/library/src/main/scala/request/decodes.scala
@@ -1,0 +1,29 @@
+package unfiltered.request
+
+/** http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3 */
+object Decodes {
+  
+  trait Decoding {
+    def unapply[A](req: HttpRequest[A]) = req match {
+      case AcceptEncoding(encs) =>
+        if (encs.exists(acceptable)) Some(req) else None
+      case _ => None
+    }
+    def acceptable(enc: String) =
+      Decodes.acceptable(encoding)(enc)
+    def encoding: String
+  }
+  
+  def acceptable(encA: String)(encB: String) =
+    encA.equalsIgnoreCase(encB) || encA == "*"
+  
+  def decoding(enc: String) =
+    new Decoding { val encoding = enc }
+  
+  /* IANA encodings. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6. */
+  val Chunked   = decoding("chunked")
+  val Identity  = decoding("identity")
+  val GZip      = decoding("gzip")
+  val Compress  = decoding("compress")
+  val Deflate   = decoding("deflate")
+}

--- a/library/src/test/scala/DecodesSpec.scala
+++ b/library/src/test/scala/DecodesSpec.scala
@@ -1,0 +1,70 @@
+package unfiltered.request
+
+import org.specs._
+
+object DecodesSpecJetty extends unfiltered.spec.jetty.Served with DecodesSpec {
+  def setup = { _.filter(unfiltered.filter.Planify(intent)) }
+}
+object DecodesSpecNetty extends unfiltered.spec.netty.Served with DecodesSpec {
+  def setup = { p => 
+    unfiltered.netty.Http(p).handler(unfiltered.netty.cycle.Planify(intent))
+  }
+}
+trait DecodesSpec extends unfiltered.spec.Hosted {
+  import unfiltered.response._
+  import unfiltered.request._
+  import unfiltered.request.{Path => UFPath}
+  
+  import dispatch._
+
+  def intent[A,B]: unfiltered.Cycle.Intent[A,B] = {
+    case GET(UFPath(Seg(ext :: Nil)) & Decodes.Chunked(_)) => ResponseString("chunked")
+    case GET(UFPath(Seg(ext :: Nil)) & Decodes.Identity(_)) => ResponseString("identity")
+    case GET(UFPath(Seg(ext :: Nil)) & Decodes.GZip(_)) => ResponseString("gzip")
+    case GET(UFPath(Seg(ext :: Nil)) & Decodes.Compress(_)) => ResponseString("compress")
+    case GET(UFPath(Seg(ext :: Nil)) & Decodes.Deflate(_)) => ResponseString("deflate")
+  }
+  
+  "Decodes should" should {
+    "match a chunked accepts encoding request as chunked" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "chunked")  as_str)
+      resp must_=="chunked"
+    }
+    "match a mixed chunked accepts encoding request as chunked" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "chunked;q=1.0, gzip; q=0.5")  as_str)
+      resp must_=="chunked"
+    }
+    "match an identity accepts encoding request as identity" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "identity")  as_str)
+      resp must_=="identity"
+    }
+    "match a mixed identity accepts encoding request as identity" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "gzip;q=1.0, identity; q=0.5")  as_str)
+      resp must_=="identity"
+    }
+    "match a gzip accepts encoding request as gzip" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "gzip")  as_str)
+      resp must_=="gzip"
+    }
+    "match a mixed gzip accepts encoding request as gzip" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "Compress;q=1.0, gzip; q=0.5")  as_str)
+      resp must_=="gzip"
+    }
+    "match a compress accepts encoding request as compress" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "compress")  as_str)
+      resp must_=="compress"
+    }
+    "match a mixed compress accepts encoding request as compress" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "deflate;q=1.0, compress; q=0.5")  as_str)
+      resp must_=="compress"
+    }
+    "match a deflate accepts encoding request as deflate" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "deflate")  as_str)
+      resp must_=="deflate"
+    }
+    "match a mixed deflate accepts encoding request as deflate" in {
+      val resp = Http(host / "test" <:< Map("Accept-Encoding" -> "deflate;q=1.0, invalid; q=0.5")  as_str)
+      resp must_=="deflate"
+    }
+  }
+}


### PR DESCRIPTION
These are modeled after the Accepts extractors. Decodes exposes extractors for IANA encoding types similarly to how Accepts does for common mime types. Peep the new spec for usage.
