### PR TITLE
introducing Underlying trait

### DIFF
--- a/filter/src/main/scala/bindings.scala
+++ b/filter/src/main/scala/bindings.scala
@@ -7,6 +7,11 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import unfiltered.Cookie
 import unfiltered.util.Optional
 
+trait Underlying extends unfiltered.Underlying {
+  type UnderlyingRequest = HttpServletRequest
+  type UnderlyingResponse = HttpServletResponse
+}
+
 class RequestBinding(req: HttpServletRequest) extends HttpRequest(req) {
   def inputStream = req.getInputStream
   def reader = req.getReader

--- a/filter/src/main/scala/plans.scala
+++ b/filter/src/main/scala/plans.scala
@@ -14,8 +14,9 @@ trait InittedFilter extends Filter {
   def destroy { }
 }
 
-object Plan {
-  type Intent = Cycle.Intent[HttpServletRequest,HttpServletResponse]
+
+object Plan extends Underlying {
+  type Intent = Cycle.Intent[UnderlyingRequest, UnderlyingResponse]
 }
 
 /** Object to facilitate Plan.Intent definitions. Type annotations
@@ -28,7 +29,8 @@ object Intent {
  * Servlet filter that wraps an Intent and adheres to standard filter
  * chain behaviour.
  */
-trait Plan extends InittedFilter {
+trait Plan extends InittedFilter with Underlying {
+
   def intent: Plan.Intent
 
   def doFilter(request: ServletRequest,

--- a/library/src/main/scala/intents.scala
+++ b/library/src/main/scala/intents.scala
@@ -3,6 +3,12 @@ package unfiltered
 import unfiltered.request.HttpRequest
 import unfiltered.response.{ResponseFunction,HttpResponse,Pass}
 
+
+trait Underlying {
+  type UnderlyingRequest
+  type UnderlyingResponse
+}
+
 object Cycle {
   /** A rountrip intent is a set of instructions for producting
    * a complete response to a request. Plans that contain intents

--- a/netty/src/main/scala/async/plans.scala
+++ b/netty/src/main/scala/async/plans.scala
@@ -7,11 +7,12 @@ import unfiltered.netty._
 import unfiltered.response.{NotFound, Pass}
 import unfiltered.request.HttpRequest
 import unfiltered.Async
+import unfiltered.netty.Underlying
 
-object Plan {
+object Plan extends Underlying{
   /** Note: The only return object a channel plan acts on is Pass */
   type Intent =
-    Async.Intent[ReceivedMessage, NHttpResponse]
+    Async.Intent[UnderlyingRequest, UnderlyingResponse]
 }
 /** Object to facilitate Plan.Intent definitions. Type annotations
  *  are another option. */
@@ -20,7 +21,8 @@ object Intent {
 }
 
 /** A Netty Plan for request-only handling. */
-trait Plan extends SimpleChannelUpstreamHandler with ExceptionHandler {
+trait Plan extends SimpleChannelUpstreamHandler with ExceptionHandler with Underlying {
+
   def intent: Plan.Intent
   override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
     val request = e.getMessage() match {

--- a/netty/src/main/scala/bindings.scala
+++ b/netty/src/main/scala/bindings.scala
@@ -22,6 +22,11 @@ object HttpConfig {
    val DEFAULT_CHARSET = "UTF-8"
 }
 
+trait Underlying extends unfiltered.Underlying {
+   type UnderlyingRequest = ReceivedMessage
+   type UnderlyingResponse = NHttpResponse
+}
+
 class RequestBinding(msg: ReceivedMessage)
 extends HttpRequest(msg) with Async.Responder[NHttpResponse] {
   private val req = msg.request

--- a/netty/src/main/scala/cycle/plans.scala
+++ b/netty/src/main/scala/cycle/plans.scala
@@ -9,9 +9,10 @@ import unfiltered.netty._
 import unfiltered.response.{ResponseFunction, Pass}
 import unfiltered.request.HttpRequest
 import unfiltered.Cycle.Intent.complete
+import unfiltered.netty.Underlying
 
-object Plan {
-  type Intent = unfiltered.Cycle.Intent[ReceivedMessage,NHttpResponse]
+object Plan extends Underlying {
+  type Intent = unfiltered.Cycle.Intent[UnderlyingRequest, UnderlyingResponse]
 }
 /** Object to facilitate Plan.Intent definitions. Type annotations
  *  are another option. */
@@ -19,7 +20,8 @@ object Intent {
   def apply(intent: Plan.Intent) = intent
 }
 /** A Netty Plan for request cycle handling. */
-trait Plan extends SimpleChannelUpstreamHandler with ExceptionHandler {
+trait Plan extends SimpleChannelUpstreamHandler with ExceptionHandler with Underlying {
+
   def intent: Plan.Intent
   override def messageReceived(ctx: ChannelHandlerContext,
                                e: MessageEvent) {


### PR DESCRIPTION
introducing Underlying trait which could be used to build on top of Unfiltered as an HTTP library. For a full example, see http://bit.ly/p7qkIt
