### PR TITLE
Oauth2: Resource Owner Password Credentials grant type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ project/plugins/src_managed/
 project/plugins/project/
 \#*\#
 *~
+# IDEA Ignores
+*.iml
+*.ipr
+*.iws
+.idea/
+.idea_modules/
+# OS X
+.DS_Store

--- a/oauth2/src/main/scala/AuthorizationServer.scala
+++ b/oauth2/src/main/scala/AuthorizationServer.scala
@@ -142,5 +142,19 @@ trait AuthorizationServer {
            )
         case _ => ErrorResponse(InvalidRequest, UnknownClientMsg, errorUri(InvalidClient), scope)
       }
-  }
+
+    case PasswordRequest(userName, password, clientId, clientSecret, scope) =>
+      client(clientId, Some(clientSecret)) match {
+        case Some(c) =>
+          resourceOwner(userName, password) match {
+            case Some(owner) =>
+              val tok = generatePasswordToken(owner, c, scope)
+              AccessTokenResponse(
+                tok.value, tok.tokenType, tok.expiresIn, tok.refresh, scope, None
+              )
+            case None => ErrorResponse(InvalidRequest, UnauthorizedClient, errorUri(InvalidClient), scope)
+          }
+        case _ => ErrorResponse(InvalidRequest, UnknownClientMsg, errorUri(InvalidClient), scope)
+      }
+    }
 }

--- a/oauth2/src/main/scala/containers.scala
+++ b/oauth2/src/main/scala/containers.scala
@@ -6,6 +6,7 @@ import unfiltered.request.{HttpRequest => Req}
 /** A ResourceOwner belongs to a Container */
 trait ResourceOwner {
   def id: String
+  def password: Option[String]
 }
 
 /** Encapsulates information sent by a Client Authorization request that may
@@ -45,6 +46,9 @@ trait Container extends ContainerResponses {
 
   /** @return Some(resourceOwner) if one is authenticated, None otherwise. None will trigger a login request */
   def resourceOwner[T](r: Req[T]): Option[ResourceOwner]
+
+  /** @return Some(resourceOwner) if they can be authenticated by the given password credentials, otherwise None */
+  def resourceOwner(userName: String, password: String): Option[ResourceOwner]
 
   /** @return true if application-specific logic determines this request was accepted, false otherwise */
   def accepted[T](r: Req[T]): Boolean

--- a/oauth2/src/main/scala/requests.scala
+++ b/oauth2/src/main/scala/requests.scala
@@ -76,3 +76,14 @@ case class RefreshTokenRequest(
   clientSecret: String,
   scope: Option[String]
 ) extends AccessRequest
+
+/**
+ * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.3.2
+ */
+case class PasswordRequest(
+  userName: String,
+  password: String,
+  clientId: String,
+  clientSecret: String,
+  scope: Option[String]
+) extends AccessRequest

--- a/oauth2/src/main/scala/tokens.scala
+++ b/oauth2/src/main/scala/tokens.scala
@@ -102,4 +102,12 @@ trait TokenStore {
    * a given resource owner
    */
   def generateClientToken(client: Client, scope: Option[String]): Token
+
+  /**
+   * @see AuthorizationServer
+   * @see PasswordRequest
+   * @notes http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.3.3
+   * @return an access token for a client, given the resource owner's credentials
+   */
+  def generatePasswordToken(owner: ResourceOwner, client: Client, scope: Option[String]): Token
 }

--- a/oauth2/src/test/scala/MockAuthServer.scala
+++ b/oauth2/src/test/scala/MockAuthServer.scala
@@ -2,7 +2,9 @@ package unfiltered.oauth2
 
 case class MockClient(id: String, secret: String, redirectUri: String) extends Client
 
-case class MockResourceOwner(id:  String) extends ResourceOwner
+case class MockResourceOwner(id:  String) extends ResourceOwner {
+  override val password = None
+}
 
 case class MockToken(val value: String, val clientId: String,
                      val redirectUri: String, val owner: String)
@@ -46,6 +48,9 @@ case class MockAuthServerProvider(cli: MockClient, owner: MockResourceOwner)
     def generateImplicitAccessToken(owner: ResourceOwner, client: Client,
                                     scope: Option[String], redirectURI: String) =
                                         mock
+
+    def generatePasswordToken(owner: ResourceOwner, client: Client,
+                              scope: Option[String]) = mock
   }
 
   trait MockContainer extends Container {
@@ -73,6 +78,11 @@ case class MockAuthServerProvider(cli: MockClient, owner: MockResourceOwner)
 
     def resourceOwner[T](r: Req[T]): Option[ResourceOwner] = {
       // would normally look for a resource owners session here
+      Some(owner)
+    }
+
+    def resourceOwner(userName: String, password: String): Option[ResourceOwner] = {
+      // would normally authenticate the resource owner
       Some(owner)
     }
 

--- a/oauth2/src/test/scala/ProtectionSpec.scala
+++ b/oauth2/src/test/scala/ProtectionSpec.scala
@@ -8,7 +8,9 @@ object ProtectionSpec extends Specification with unfiltered.spec.jetty.Served {
   import unfiltered.request.{Path => UFPath}
   import dispatch._
 
-  class User(val id: String) extends ResourceOwner
+  class User(val id: String) extends ResourceOwner {
+    override val password = None
+  }
 
   object User {
     import javax.servlet.http.{HttpServletRequest}


### PR DESCRIPTION
Hi,

I am strongly interested in getting the OAuth2 implementation of Unfiltered into a production-ready state soon. For a start, I implemented the Resource Owner Password Credentials grant type of the OAuth2 spec, which apparently hasn't been covered yet in your oauth2 branch.

Best regards,

Daniel
