### PR TITLE
Oauth2: Fixing token requests for client credentials and password grant type

### DIFF
--- a/oauth2/src/main/scala/authorizations.scala
+++ b/oauth2/src/main/scala/authorizations.scala
@@ -217,7 +217,7 @@ trait Authorized extends AuthorizationProvider
         grantType.get match {
 
           case ClientCredentials =>
-            auth(ClientCredentialsRequest(clientId.get, clientSecret.get, scope.get)) match {
+            auth(ClientCredentialsRequest(clientId.get, clientSecret.get, scope.getOrElse(Nil))) match {
               case AccessTokenResponse(accessToken, kind, expiresIn, refreshToken, scope, _) =>
                 accessResponder(
                   accessToken, kind, expiresIn, refreshToken, scope
@@ -229,7 +229,7 @@ trait Authorized extends AuthorizationProvider
           case Password =>
             (userName.get, password.get) match {
               case (Some(u), Some(pw)) =>
-                auth(PasswordRequest(u, pw, clientId.get, clientSecret.get, scope.get)) match {
+                auth(PasswordRequest(u, pw, clientId.get, clientSecret.get, scope.getOrElse(Nil))) match {
                   case AccessTokenResponse(accessToken, kind, expiresIn, refreshToken, scope, _) =>
                     accessResponder(
                       accessToken, kind, expiresIn, refreshToken, scope

--- a/oauth2/src/test/scala/AuthorizationSpec.scala
+++ b/oauth2/src/test/scala/AuthorizationSpec.scala
@@ -186,6 +186,17 @@ object AuthorizationSpec
          map must havePair("error_description", "client_secret is required")
        }
     }
+    "accept our mock client" in {
+       val (head, body) = http(token << Map(
+         "grant_type" -> "client_credentials",
+         "client_id" -> client.id,
+         "client_secret" -> client.secret,
+         "redirect_uri" -> client.redirectUri
+       ) >+ { r => (r >:> { h => r }, r as_str ) })
+       json(body) { map =>
+         map must haveKey("access_token")
+       }
+    }
   }
 
   //
@@ -246,6 +257,18 @@ object AuthorizationSpec
        json(body) { map =>
          map must havePair("error", "invalid_request")
          map must havePair("error_description", "client_secret is required")
+       }
+    }
+    "accept our mock user's password credentials" in {
+      val (head, body) = http(token << Map(
+         "grant_type" -> "password",
+         "client_id" -> client.id,
+         "client_secret" -> client.secret,
+         "username" -> owner.id,
+         "password" -> password
+       ) >+ { r => (r >:> { h => r }, r as_str ) })
+       json(body) { map =>
+         map must haveKey("access_token")
        }
     }
   }


### PR DESCRIPTION
Changing the scope from Option[String] to Seq[String] resulted in
failure when these token requests lacked a scope parameter.
