### PR TITLE
OAuth2: Fixing Cache-Control and Pragma headers for access token responses. 

### DIFF
--- a/oauth2/src/main/scala/authorizations.scala
+++ b/oauth2/src/main/scala/authorizations.scala
@@ -91,13 +91,13 @@ trait Authorized extends AuthorizationProvider
   }
 
   protected def accessResponder(accessToken: String, kind: String, expiresIn: Option[Int], refreshToken: Option[String], scope:Seq[String]) =
-    Json(Map(AccessTokenKey -> accessToken, TokenType -> kind) ++
+    CacheControl("no-store") ~> Pragma("no-cache") ~> Json(Map(AccessTokenKey -> accessToken, TokenType -> kind) ++
         expiresIn.map (ExpiresIn -> (_:Int).toString) ++
         refreshToken.map (RefreshToken -> _) ++
         (scope match {
           case Seq() => None
           case xs => Some(scopeEncoder(xs))
-        }).map (Scope -> _)) ~> CacheControl("no-store")
+        }).map (Scope -> _))
 
   protected def errorResponder(error: String, desc: String, euri: Option[String], state: Option[String]) =
     Json(Map(Error -> error, ErrorDescription -> desc) ++


### PR DESCRIPTION
Token responses must have a Cache-Control header of "no-store" and
a Pragma header of "no-cache", according to
http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.2.2

Pragma header was missing, and Cache-Control header was appended
_after_ the body and thus not inluded in the response either.
