### PR TITLE
XAuthorizedScopes needs to be stored in the request as a Seq.

### DIFF
--- a/oauth2/src/main/scala/protections.scala
+++ b/oauth2/src/main/scala/protections.scala
@@ -34,7 +34,7 @@ trait ProtectionLike extends Plan {
       case Left(msg) => errorResponse(Unauthorized, msg, request)
       case Right((user, scopes)) =>
         request.underlying.setAttribute(OAuth2.XAuthorizedIdentity, user.id)
-        scopes.map(request.underlying.setAttribute(OAuth2.XAuthorizedScopes, _))
+        request.underlying.setAttribute(OAuth2.XAuthorizedScopes, scopes)
         Pass
     }
 


### PR DESCRIPTION
If the XAuthorizedScopes attribute is a plain string, this causes a match fail later. Corresponds to previous changes converting cope to a Seq[String].
