### PR TITLE
OAuth2 Resource Server handling of authentication schemes

### DIFF
--- a/oauth2/src/main/scala/protections.scala
+++ b/oauth2/src/main/scala/protections.scala
@@ -26,32 +26,21 @@ trait ProtectionLike extends Plan {
   val schemes: Seq[AuthScheme]
   def intent = ((schemes map {_.intent(this)}) :\ fallback) {_ orElse _}
   def fallback: Plan.Intent = {
-    case request => println("did not match any scheme in %s" format schemes);errorResponse(Unauthorized, "", request)
+    case request =>
+      println("did not match any scheme in %s" format schemes)
+      // if no authentication token is provided at all, demand the first authentication scheme of all that are supported:
+      schemes.head.errorResponse(Unauthorized, "", request)
   }
 
-  def authenticate[T <: HttpServletRequest](token: AccessToken, request: HttpRequest[T]) =
+  def authenticate[T <: HttpServletRequest](token: AccessToken, request: HttpRequest[T])(errorResp: (String => ResponseFunction[Any])) =
     source.authenticateToken(token, request) match {
-      case Left(msg) => errorResponse(Unauthorized, msg, request)
+      //case Left(msg) => errorResponse(Unauthorized, msg, request)
+      case Left(msg) => errorResp(msg)
       case Right((user, scopes)) =>
         request.underlying.setAttribute(OAuth2.XAuthorizedIdentity, user.id)
         request.underlying.setAttribute(OAuth2.XAuthorizedScopes, scopes)
         Pass
     }
-
-  def errorString(status: String, description: String) =
-    """error="%s" error_description="%s" """.trim format(status, description)
-
-  def errorResponse[T](status: Status, description: String,
-      request: HttpRequest[T]): ResponseFunction[Any] = (status, description) match {
-    case (Unauthorized, "") => Unauthorized ~> WWWAuthenticate("Bearer") ~> ResponseString("Bearer")
-    case (Unauthorized, _)  =>
-      Unauthorized ~> WWWAuthenticate("Bearer\n" + errorString("invalid_token", description)) ~>
-      ResponseString(errorString("invalid_token", description))
-
-    case (BadRequest, _)    => status ~> ResponseString(errorString("invalid_request", description))
-    case (Forbidden, _)     => status ~> ResponseString(errorString("insufficient_scope", description))
-    case _ => status ~> ResponseString(errorString(status.toString, description))
-  }
 }
 
 /** Represents the authorization source that issued the access token. */
@@ -64,6 +53,36 @@ trait AuthSource {
 /** Represents the authentication scheme. */
 trait AuthScheme {
   def intent(protection: ProtectionLike): Plan.Intent
+  def errorString(status: String, description: String) =
+    """error="%s" error_description="%s" """.trim format(status, description)
+  val challenge: String
+  /**
+   * An error header, consisting of the challenge and possibly an error and error_description attribute
+   * (this depends on the authentication scheme).
+   */
+  def errorHeader(error: Option[String] = None, description: Option[String] = None) = {
+    description.foldLeft(
+      error.foldLeft(challenge) ((current, error) =>
+        """%s error="%s"""".format(current, error))) { (current, description) =>
+      current + ",\nerror_description=\"%s\"".trim.format(description)}
+  }
+
+  /**
+   * The response for failed authentication attempts. Intended to be overridden by authentication schemes that have
+   * differing requirements.
+   */
+  val failedAuthenticationResponse: (String => ResponseFunction[Any]) = { msg =>
+    Unauthorized ~> WWWAuthenticate(errorHeader(Some("invalid_token"), Some(msg))) ~>
+      ResponseString(errorString("invalid_token", msg))
+  }
+  def errorResponse[T](status: Status, description: String,
+      request: HttpRequest[T]): ResponseFunction[Any] = (status, description) match {
+    case (Unauthorized, "") => Unauthorized ~> WWWAuthenticate(challenge) ~> ResponseString(challenge)
+    case (Unauthorized, _)  => failedAuthenticationResponse(description)
+    case (BadRequest, _)    => status ~> ResponseString(errorString("invalid_request", description))
+    case (Forbidden, _)     => status ~> ResponseString(errorString("insufficient_scope", description))
+    case _ => status ~> ResponseString(errorString(status.toString, description))
+  }
 }
 trait AccessToken
 
@@ -71,6 +90,7 @@ case class BearerToken(value: String) extends AccessToken
 
 /** Represents Bearer auth. */
 trait BearerAuth extends AuthScheme {
+  val challenge = "Bearer"
   val defaultBearerHeader = """Bearer ([\w\d!#$%&'\(\)\*+\-\.\/:<=>?@\[\]^_`{|}~\\,;]+)""".r
   def header = defaultBearerHeader
 
@@ -85,7 +105,7 @@ trait BearerAuth extends AuthScheme {
 
   def intent(protection: ProtectionLike) = {
     case Authorization(BearerHeader(token)) & request =>
-      protection.authenticate(BearerToken(token), request)
+      protection.authenticate(BearerToken(token), request) { failedAuthenticationResponse }
   }
 }
 
@@ -93,6 +113,7 @@ object BearerAuth extends BearerAuth {}
 
 /** Represents Bearer auth. */
 trait QParamBearerAuth extends AuthScheme {
+  val challenge = "Bearer"
   val defaultQueryParam = "bearer_token"
   def queryParam = defaultQueryParam
 
@@ -102,7 +123,7 @@ trait QParamBearerAuth extends AuthScheme {
 
   def intent(protection: ProtectionLike) = {
     case Params(BearerParam(token)) & request =>
-      protection.authenticate(BearerToken(token), request)
+      protection.authenticate(BearerToken(token), request) { failedAuthenticationResponse }
   }
 }
 
@@ -111,6 +132,8 @@ object QParamBearerAuth extends QParamBearerAuth {}
 /** Represents MAC auth. */
 trait MacAuth extends AuthScheme {
   import unfiltered.mac.{Mac, MacAuthorization}
+
+  val challenge = "MAC"
 
   def algorithm: String
 
@@ -123,21 +146,33 @@ trait MacAuth extends AuthScheme {
            case Some(key) =>
               Mac.sign(req, nonce, ext, bodyhash, key, algorithm).fold({ err =>
                 println("err signing %s" format err)
-                protection.errorResponse(BadRequest, err, req)
+                errorResponse(Unauthorized, err, req)
               }, { sig =>
                 println("sig %s" format sig)
                 println("mac %s" format mac)
-                if(sig == mac) protection.authenticate(MacAuthToken(id, key, nonce, bodyhash, ext), req)
-                else protection.errorResponse(BadRequest, "invalid MAC signature", req)
+                if(sig == mac) protection.authenticate(MacAuthToken(id, key, nonce, bodyhash, ext), req) {
+                  failedAuthenticationResponse
+                }
+                else errorResponse(Unauthorized, "invalid MAC signature", req)
              })
            case _ =>
              println("could not find token for id %s" format id)
-             protection.errorResponse(BadRequest, "invalid token", req)
+             errorResponse(Unauthorized, "invalid token", req)
          }
       }
       catch {
-        case e: Exception => protection.errorResponse(BadRequest, "invalid MAC header.", req)
+        case e: Exception => errorResponse(Unauthorized, "invalid MAC header.", req)
       }
+  }
+
+  /**
+   * Whereas the Bearer token is supposed to return an error code in the error attribute and a human-readable
+   * error description in the error_description attribute of the WWW-Authenticate header, for the MAC
+   * authentication scheme, a human-readable error message may be supplied in the error attribute
+   * (see http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-00#section-4.1)
+   */
+  override val failedAuthenticationResponse: (String => ResponseFunction[Any]) = { msg =>
+    Unauthorized ~> WWWAuthenticate(errorHeader(Some(msg))) ~> ResponseString("""error="%s"""".format(msg))
   }
 }
 

--- a/oauth2/src/test/scala/ProtectionSpec.scala
+++ b/oauth2/src/test/scala/ProtectionSpec.scala
@@ -65,11 +65,35 @@ object ProtectionSpec extends Specification with unfiltered.spec.jetty.Served {
       }
     }
 
+    // see http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4.1
     "fail on a bad Bearer header" in {
       val bearer_header = Map("Authorization" -> "Bearer bad_token")
       println(host / "user" <:< bearer_header as_str)
       Http.when(_ == 401)(host / "user" <:< bearer_header as_str) must_== """error="%s" error_description="%s" """.trim.format("invalid_token", "bad token")
+      val head = Http.when(_ == 401)(host / "user" <:< bearer_header >:> { h => h })
+      head.get("WWW-Authenticate") must_!= (None)
+      val wwwAuth = head("WWW-Authenticate")
+      val expected = "Bearer error=\"%s\",error_description=\"%s\"".trim.format("invalid_token", "bad token")
+      wwwAuth.head must_== expected
     }
+
+    // see http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4.1
+    "fail without returning an error code and description on missing authentication information" in {
+      val head = Http.when(_ == 401)(host / "user" >:> { h => h })
+      head.get("WWW-Authenticate") must_!= (None)
+      val wwwAuth = head("WWW-Authenticate")
+      wwwAuth.head must_== "Bearer"
+    }
+    // see http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-00#section-4.1
+    "fail on a bad MAC header" in {
+      val macHeader = Map("Authorization" -> """MAC id="bogus",nonce="123:y",bodyhash="bogus",mac="bogus"""")
+      val head = Http.when(_ == 401)(host / "user" <:< macHeader >:> { h => h })
+      head.get("WWW-Authenticate") must_!= (None)
+      val wwwAuth = head("WWW-Authenticate")
+      val expected = "MAC error=\"%s\"".trim.format("invalid token")
+      wwwAuth.head must_== expected
+    }
+
 /*
     "authenticate a valid access token via MAC header" in {
       val mac_header = Map("Authorization" -> """MAC id="%s",nonce="123:x",bodyhash="x",mac="x" """.format(GoodMacToken).trim)


### PR DESCRIPTION
Improved support for alternative authentication schemes on the resource server side, most notably for the MAC scheme, which also requires different use of attributes in the WWW-Authenticate header.

By only having the MacAuth in the list of supported schemes, it's now possible to inform clients correctly about the required authentication scheme, instead of always returning the "Bearer" challenge when no token was provided at all.

Also, adding some additional tests to ensure we are in line with the current specs for OAuth2 as well as Bearer and Mac schemes.
