### PR TITLE
Making errorHeader more robust and generic

### DIFF
--- a/oauth2/src/main/scala/protections.scala
+++ b/oauth2/src/main/scala/protections.scala
@@ -61,10 +61,10 @@ trait AuthScheme {
    * (this depends on the authentication scheme).
    */
   def errorHeader(error: Option[String] = None, description: Option[String] = None) = {
-    description.foldLeft(
-      error.foldLeft(challenge) ((current, error) =>
-        """%s error="%s"""".format(current, error))) { (current, description) =>
-      current + ",\nerror_description=\"%s\"".trim.format(description)}
+    val attrs = List("error" -> error, "error_description" -> description).collect { case (key, Some(value)) => key -> value }
+    attrs.tail.foldLeft(
+      attrs.headOption.foldLeft(challenge) { case (current, (key, value)) => """%s %s="%s"""".format(current, key, value) }
+    ) { case (current, (key, value)) => current + ",\n%s=\"%s\"".format(key, value) }
   }
 
   /**


### PR DESCRIPTION
Sorry for the additional effort, Doug, but I noticed that the errorHeader method I introduced with my last pull request should probably be more robust than the first, somewhat naive implementation:

While it was behaving correctly for input that is in accordance with the Bearer and MAC specs, it was prone to producing an invalid header value if an error description argument was given, but no error argument. This new version would still produce a syntactically correct value for the WWW-Authenticate header.
