### PR TITLE
OAuth2: Providing client identity to Resource Server plans

### DIFF
--- a/oauth2/src/main/scala/oauth2.scala
+++ b/oauth2/src/main/scala/oauth2.scala
@@ -2,6 +2,7 @@ package unfiltered.oauth2
 
 object OAuth2 {
   val XAuthorizedIdentity = "X-Authorized-Identity"
+  val XAuthorizedClientIdentity = "X-Authorized-Client-Identity"
   val XAuthorizedScopes = "X-Authorized-Scopes"
 }
 

--- a/oauth2/src/main/scala/protections.scala
+++ b/oauth2/src/main/scala/protections.scala
@@ -36,8 +36,9 @@ trait ProtectionLike extends Plan {
     source.authenticateToken(token, request) match {
       //case Left(msg) => errorResponse(Unauthorized, msg, request)
       case Left(msg) => errorResp(msg)
-      case Right((user, scopes)) =>
+      case Right((user, client, scopes)) =>
         request.underlying.setAttribute(OAuth2.XAuthorizedIdentity, user.id)
+        request.underlying.setAttribute(OAuth2.XAuthorizedClientIdentity, client.id)
         request.underlying.setAttribute(OAuth2.XAuthorizedScopes, scopes)
         Pass
     }
@@ -45,7 +46,7 @@ trait ProtectionLike extends Plan {
 
 /** Represents the authorization source that issued the access token. */
 trait AuthSource {
-  def authenticateToken[T](token: AccessToken, request: HttpRequest[T]): Either[String, (ResourceOwner, Seq[String])]
+  def authenticateToken[T](token: AccessToken, request: HttpRequest[T]): Either[String, (ResourceOwner, Client, Seq[String])]
 
   def realm: Option[String] = None
 }

--- a/oauth2/src/test/scala/ProtectionSpec.scala
+++ b/oauth2/src/test/scala/ProtectionSpec.scala
@@ -11,6 +11,12 @@ object ProtectionSpec extends Specification with unfiltered.spec.jetty.Served {
     override val password = None
   }
 
+  object TestClient extends Client {
+    def redirectUri = "http://example.com"
+    def secret = "client_secret"
+    def id = "test_client"
+  }
+
   object User {
     import javax.servlet.http.{HttpServletRequest}
 
@@ -26,12 +32,13 @@ object ProtectionSpec extends Specification with unfiltered.spec.jetty.Served {
 
   def setup = { server =>
     val source = new AuthSource {
-      def authenticateToken[T](access_token: AccessToken, request: HttpRequest[T]): Either[String, (ResourceOwner, Seq[String])] =
+      def authenticateToken[T](
+          access_token: AccessToken, request: HttpRequest[T]): Either[String, (ResourceOwner, Client, Seq[String])] =
         access_token match {
           case BearerToken(GoodBearerToken) =>
-            Right((new User("test_user"), Nil))
+            Right((new User("test_user"), TestClient, Nil))
           case MacAuthToken(GoodMacToken, _, _, _, _) =>
-            Right((new User("test_user"), Nil))
+            Right((new User("test_user"), TestClient, Nil))
           case _ =>
             Left("bad token")
         }


### PR DESCRIPTION
Since an access token essentially authenticates both the Resource Owner that authorized the client and
the Client to which the token was issued, the client identity is now made available to resource server plans, in addition to the resource owner identity and the authorized scopes.
