### PR TITLE
Html(...) does not add correct doctype. This Html5 class does this

### DIFF
--- a/library/src/main/scala/response/writers.scala
+++ b/library/src/main/scala/response/writers.scala
@@ -24,3 +24,13 @@ extends ResponseFunction[Any] {
       override val charset = Charset.this.charset
     }
 }
+case class Html5(nodes: scala.xml.NodeSeq) extends ComposeResponse(HtmlContent ~> {
+  val w = new java.io.StringWriter()
+  val html = nodes.head match {
+    case <html>{_*}</html> => nodes.head
+    case _ => <html>{nodes}</html>
+  }
+  xml.XML.write( w, html, "UTF-8", xmlDecl = false, doctype =
+    xml.dtd.DocType( "html", xml.dtd.SystemID( "about:legacy-compat" ), Nil ))
+  ResponseString(w.toString)
+})


### PR DESCRIPTION
Following discussion on scalate group. https://groups.google.com/d/topic/scalate/WfUpmIUKW2Q/discussion -- please improve, this was a first working attempt. 
