### PR TITLE
Fix NoSuchElementException for parameterValues.

### DIFF
--- a/netty/src/main/scala/bindings.scala
+++ b/netty/src/main/scala/bindings.scala
@@ -54,7 +54,7 @@ extends HttpRequest(msg) with Async.Responder[NHttpResponse] {
   def uri = req.getUri
 
   def parameterNames = params.keySet.iterator
-  def parameterValues(param: String) = params(param)
+  def parameterValues(param: String) = params.getOrElse(param, Seq.empty)
   def headers(name: String) = new JIteratorIterator(req.getHeaders(name).iterator)
 
   @deprecated("use the header extractor request.Cookies instead")
@@ -112,7 +112,7 @@ case class ReceivedMessage(
       }
       val future = event.getChannel.write(
         defaultResponse(
-          unfiltered.response.Server("Scala Netty Unfiltered Server") ~> 
+          unfiltered.response.Server("Scala Netty Unfiltered Server") ~>
             rf ~> closer
         )
       )

--- a/netty/src/test/scala/spec.scala
+++ b/netty/src/test/scala/spec.scala
@@ -36,6 +36,14 @@ class RequestSpec extends Specification {
     "return url parameters" in {
       req.parameterValues("param1")(0) must_== "value 1"
     }
+    "return empty seq for missing parameter with other parameters present" in {
+      req.parameterValues("param42") must_== Seq.empty
+    }
+    "return empty seq for missing parameter when no parameters are present at all" in {
+      val nreq = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/")
+      val req = new RequestBinding(ReceivedMessage(nreq, null, null))
+      req.parameterValues("param42") must_== Seq.empty
+    }
     "return a working reader" in {
       // Also tests inputstream
       req.reader.readLine must_== payload


### PR DESCRIPTION
When at least one other query parameter is present, calling
parameterValues with a non-existent parameter returns an empty seq.
However, when no query parameters are present at all, the same
results in a NoSuchElementException. This commit fixes that issue
in the netty bindings.
