### PR TITLE
Find path suffix only from path part of uri

### DIFF
--- a/json/src/test/scala/JsonpSpec.scala
+++ b/json/src/test/scala/JsonpSpec.scala
@@ -11,6 +11,7 @@ object JsonpSpec extends Specification  with unfiltered.spec.jetty.Served {
 
   class TestPlan extends unfiltered.filter.Planify({
     case GET(UFPath("/jsonp") & Jsonp(callback)) => ResponseString(callback.wrap("[42]"))
+    case GET(UFPath("/jsonp.json") & Jsonp(callback)) => ResponseString(callback.wrap("[42]"))
     case GET(UFPath("/jsonp/optional") & Jsonp.Optional(callback)) => ResponseString(callback.wrap("[42]"))
     case GET(UFPath("/jsonp/lift-json") & Jsonp(callback)) => callback respond {
       import net.liftweb.json.JsonAST._
@@ -31,6 +32,10 @@ object JsonpSpec extends Specification  with unfiltered.spec.jetty.Served {
   "Jsonp should" should {
     "match an text/javascript accepts request with callback, wrapping response body in callback" in {
       val resp = http(host / "jsonp" <:< Map("Accept" -> "text/javascript") <<? Map("callback" -> "onResp") as_str)
+      resp must_=="onResp([42])"
+    }
+    "match an */* accepts request with path extension and callback, wrapping response body in callback" in {
+      val resp = http(host / "jsonp.json" <:< Map("Accept" -> "*/*") <<? Map("callback" -> "onResp") as_str)
       resp must_=="onResp([42])"
     }
    "not match an text/javascript accepts request without a callback" in {

--- a/library/src/main/scala/request/accepts.scala
+++ b/library/src/main/scala/request/accepts.scala
@@ -9,7 +9,7 @@ object Accepts {
     val ext: String
 
     def unapply[T](r: HttpRequest[T]) = {
-      val pathSuffix = r.uri.split("[.]").lastOption
+      val pathSuffix = Path(r).split("[.]").lastOption
       r match {
         case Accept(values) =>
           if(values.exists { _.equalsIgnoreCase(contentType) })


### PR DESCRIPTION
Hi!

I came across a problem in using jsonp convenience extractors for 'real' cross-domain jsonp requests, as browser always (?) sets accepts header to '*/*' and in this case only path suffix is used for matching Accepts. However, pathSuffix also included query string and hence in case of jsonp, also callback=...

The other possible fix would be to allow matching jsonp with '*/*' + callback only, without requiring path suffix? What do you think?
