### PR TITLE
Tiny fix in url generation for Jetty Https Server

### DIFF
--- a/jetty/src/main/scala/secured.scala
+++ b/jetty/src/main/scala/secured.scala
@@ -1,4 +1,3 @@
-
 package unfiltered.jetty
 
 object Https {
@@ -12,7 +11,7 @@ object Https {
 
 case class Https(port: Int, host: String) extends Server with Ssl {
   type ServerBuilder = Https
-  val url = "http://%s:%d/" format (host, port)
+  val url = "https://%s:%d/" format (host, port)
   def sslPort = port
   sslConn.setHost(host)
 }


### PR DESCRIPTION
It was missing the "s" in the uri scheme.
