### PR TITLE
Websocket encoder should follows specification with regards to payload length

### DIFF
--- a/netty-websockets/src/main/scala/encoder.scala
+++ b/netty-websockets/src/main/scala/encoder.scala
@@ -30,7 +30,7 @@ class Draft14WebSocketFrameEncoder extends OneToOneEncoder {
           val rbytes = data.readableBytes
           val blen = {
             if(rbytes < 126) rbytes + 2       // 1 header byte + 1 len byte
-            else if(rbytes == 126) rbytes + 4 // 1 header byte + 3 len bytes (1 + 2 extra)
+            else if(rbytes < 65536) rbytes + 4 // 1 header byte + 3 len bytes (1 + 2 extra)
             else rbytes + 10                  // 1 header byte + 9 len bytes (1 + 8 extra)
           }
 


### PR DESCRIPTION
This change addresses "minimal number of bytes MUST be used to encode the length" issue that appears in Chrome 18 when message length is 127 < n < 65536.

See http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17 section 5.2, subsection "Payload length"
