### PR TITLE
Added specs2 support for testing unfiltered apps

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -14,6 +14,13 @@ object Shared {
       case _ => sys.error("specs not supported for scala version %s" format sv)
     }
 
+  def specs2Dep(sv: String) =
+    sv.split("[.-]").toList match {
+      case "2" :: "8" :: _ => "org.specs2" % "specs2_2.8.2" % "1.5"      
+      case "2" :: "9" :: _ => "org.specs2" % "specs_2.9.1" % "1.11"
+      case _ => sys.error("specs2 not supported for scala version %s" format sv)
+    }
+
   val dispatchVersion = "0.8.8"
   def dispatchDeps =
     "net.databinder" %% "dispatch-mime" % dispatchVersion ::
@@ -58,7 +65,7 @@ object Unfiltered extends Build {
     Project("unfiltered-all", file(".")).delegateTo(setup).aggregate(
             library, filters, filtersAsync , uploads, filterUploads,
             nettyUploads, util, jetty,
-            jettyAjpProject, netty, nettyServer, json, specHelpers,
+            jettyAjpProject, netty, nettyServer, json, specHelpers, specs2Helpers,  
             scalaTestHelpers, websockets, oauth, agents)
 
   lazy val library: Project =
@@ -101,6 +108,9 @@ object Unfiltered extends Build {
 
   lazy val specHelpers =
     module("spec")().dependsOn(filters, jetty, nettyServer)
+
+  lazy val specs2Helpers =
+    module("specs2")().dependsOn(filters, jetty, nettyServer)
 
   lazy val scalaTestHelpers =
     module("scalatest")().dependsOn(jetty, nettyServer)

--- a/specs2/build.sbt
+++ b/specs2/build.sbt
@@ -1,0 +1,7 @@
+description := "Facilitates testing Unfiltered servers with Specs2"
+
+libraryDependencies <++= scalaVersion { v =>
+  Shared.specs2Dep(v) :: Shared.dispatchDeps
+}
+
+resolvers += "scala-tools snapshots" at "http://scala-tools.org/repo-snapshots/"

--- a/specs2/src/main/scala/unfiltered/specs2/Hosted.scala
+++ b/specs2/src/main/scala/unfiltered/specs2/Hosted.scala
@@ -1,0 +1,17 @@
+package unfiltered
+package specs2
+
+import dispatch._
+
+/**
+ * @author Erlend Hamnaberg<erlend@hamnaberg.net>
+ */
+trait Hosted {
+  val port = unfiltered.util.Port.any
+  val host = :/("localhost", port)
+  def http[T](handler: Handler[T]): T = {
+    val h = new Http
+    try { h(handler) }
+    finally { h.shutdown() }
+  }
+}

--- a/specs2/src/main/scala/unfiltered/specs2/jetty/Served.scala
+++ b/specs2/src/main/scala/unfiltered/specs2/jetty/Served.scala
@@ -1,0 +1,33 @@
+package unfiltered.specs2
+package jetty
+
+import unfiltered.specs2.Hosted
+import org.specs2.specification.{BaseSpecification, Step, Fragments}
+
+
+trait Planned extends Served {
+
+  def setup = _.plan(unfiltered.filter.Planify(intent))
+
+  def intent[A, B]: unfiltered.Cycle.Intent[A, B]
+}
+
+trait Served extends Hosted with BaseSpecification {
+
+  import unfiltered.jetty._
+
+  def after = {
+    server.stop()
+    server.destroy()
+  }
+
+  def before = {
+    server.start()
+  }
+
+  def setup: (Server => Server)
+
+  lazy val server = setup(Http(port))
+
+  override def map(fs: =>Fragments) = Step(before) ^ fs ^ Step(after)
+}


### PR DESCRIPTION
Had to add scala-tools back as a snapshot source to make this work.

There is one problem with this; Specs2 2.8.x has a snapshot
dependency on scalaz. Not sure how to deal with this.
