### PR TITLE
Memory usage when uploading a file

### DIFF
--- a/netty-uploads/src/main/scala/request/uploads.scala
+++ b/netty-uploads/src/main/scala/request/uploads.scala
@@ -160,9 +160,9 @@ extends AbstractDiskExtractor[RequestBinding] with TupleGenerator {
 class StreamedFileWrapper(item: IOFileUpload)
 extends AbstractStreamedFile
   with unfiltered.request.io.FileIO {
-  import java.io.{ByteArrayInputStream => JByteArrayInputStream}
+  import java.io.{FileInputStream => JFileInputStream}
 
-  val bstm = new JByteArrayInputStream(item.get)
+  val bstm = new JFileInputStream(item.getFile)
 
   def write(out: JFile): Option[JFile] = allCatch.opt {
     stream { stm =>


### PR DESCRIPTION
I changed ByteArrayInputStream in StreamedFileWrapper to use FileInputStream.

The reason for this change is that IOFileUpload.get actually reads the entire file into memory, possibly causing an out of memory exception with large files. Using getFile will give actual stream.

Please consider using this fix.
