### PR TITLE
Workaround for unsound type parameter inference.

### DIFF
--- a/oauth/src/main/scala/oauth.scala
+++ b/oauth/src/main/scala/oauth.scala
@@ -157,7 +157,7 @@ trait OAuthed extends OAuthProvider with unfiltered.filter.Plan {
       } yield {
         authorize(token.get, request) match {
           case Failure(code, msg) => fail(code, msg)
-          case HostResponse(resp) => Ok ~> resp
+          case HostResponse(resp) => Ok ~> (resp.asInstanceOf[ResponseFunction[Any]])
           case AuthorizeResponse(callback, token, verifier) => callback match {
             case OAuth.Oob => users.oobResponse(verifier)
             case _ => Redirect("%s%soauth_token=%s&oauth_verifier=%s" format(


### PR DESCRIPTION
Issue was fixed in 2.10.x Scala compiler (bug SI-5189),
so the given piece of code would infer the type of resp
to be ResponseFunction[Nothing].
Type parameter A in ReponseFunction would have to be covariant
in order to infer ReponseFunction[Any].
Casting is a bit ugly, but we also used it in the scala library as otherwise
it would require quite a bit of refactoring.
With this change unfiltered compiles with 2.10.0-M5 (or at least a revision close to it).
