### PR TITLE
Fix for #139

### DIFF
--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -152,7 +152,7 @@ case class Resources(base: java.net.URL,
              p.startsWith(".") ||
              p.endsWith(".")) => None
         case path =>
-          Resolve(new URL(base, path))
+          Resolve(new URL(base, decoded))
       }
     }
 


### PR DESCRIPTION
Simple change, don't use windows separators when reconstructing URL after path validation.
