### PR TITLE
Fix for FsResolver URL decoding of paths

### DIFF
--- a/netty-server/src/main/scala/resources/resolvers.scala
+++ b/netty-server/src/main/scala/resources/resolvers.scala
@@ -13,7 +13,7 @@ object Resolve {
   }
   val FsResolver: Resolver = {
     case fs if (fs.startsWith("file:")) =>
-      { u => Some(FileSystemResource(new File(u.getFile))) }
+      { u => Some(FileSystemResource(new File(u.toURI))) }
   }
   val DefaultResolver = FsResolver orElse JarResolver orElse ({
     case _ => { u => None }


### PR DESCRIPTION
There was a bug in the FsResolver that caused failures when the path (which was passed in as a URL) contains URL encoded characters (e.g. " " -> "%20").  
