### PR TITLE
If sent an empty auth header, basic auth extractor shouldn't blow up

### DIFF
--- a/library/src/main/scala/request/auths.scala
+++ b/library/src/main/scala/request/auths.scala
@@ -7,7 +7,7 @@ object BasicAuth {
 
   /** @return Some(user, pass) or None */
   def unapply[T](r: Req[T]) = r match {
-    case Authorization(auth) => {
+    case Authorization(auth) if !auth.isEmpty => {
       val tok = new java.util.StringTokenizer(auth)
       tok.nextToken match {
         case "Basic" =>

--- a/library/src/test/scala/BasicAuthSpec.scala
+++ b/library/src/test/scala/BasicAuthSpec.scala
@@ -22,6 +22,7 @@ trait BasicAuthSpec extends unfiltered.spec.Hosted {
       case ("test", "secret") => ResponseString("pass")
       case _ => ResponseString("fail")
     }
+    case _ => ResponseString("not found")
   }
 
   "Basic Auth" should {
@@ -33,6 +34,10 @@ trait BasicAuthSpec extends unfiltered.spec.Hosted {
     "not authenticate an invalid user" in {
       val resp = http(host / "secret" as_!("joe", "shmo") as_str)
       resp must_=="fail"
+    }
+    "not authenticate an empty Authorization header" in {
+      val resp = http(host / "secret" <:< Map("Authorization" -> "") as_str)
+      resp must_=="not found"
     }
   }
 }


### PR DESCRIPTION
This is because of the string tokenizer so just checking if header is empty.
