### PR TITLE
[unfiltered-oauth] Fix for whitespace bug in Authorization header parsing.

### DIFF
--- a/oauth/src/main/scala/oauth.scala
+++ b/oauth/src/main/scala/oauth.scala
@@ -24,7 +24,7 @@ object OAuth {
   /** Authorization: OAuth header extractor */
   object Header {
     import Encoding._
-    val KeyVal = """(\w+)="([\w|:|\/|.|%|-]+)" """.trim.r
+    val KeyVal = """[ ]?(\w+)="([\w|:|\/|.|%|-]+)" """.trim.r
     val keys = Set.empty + "realm" + ConsumerKey + TokenKey + SignatureMethod +
       Sig + Timestamp + Nonce + Callback + Verifier + Version
 


### PR DESCRIPTION
1 commit : Committing fix to Authorization header parsing ( handling an optional space after the comma separator that separates auth parameters ) in oauth.scala

Details here : http://oauth.net/core/1.0/#auth_header

The RFC 2617 spec for defining auth headers is here : http://tools.ietf.org/html/rfc2617
