### PR TITLE
Served no longer fails due to server reuse

### DIFF
--- a/scalatest/build.sbt
+++ b/scalatest/build.sbt
@@ -1,7 +1,3 @@
 description := "Facilitates testing Unfiltered servers with ScalaTest"
 
-libraryDependencies <++= scalaVersion(v => Seq(v.split('.').toList match {
-  case "2" :: "9" :: "1" :: _ => "org.scalatest" % "scalatest_2.9.1" % "1.6.1"
-  case "2" :: "9" :: _ => "org.scalatest" % "scalatest_2.9.0-1" % "1.6.1"
-  case _ => "org.scalatest" %% "scalatest" % "1.9.1"
-}) ++ Common.dispatchDeps)
+libraryDependencies ++= Common.dispatchDeps :+ "org.scalatest" %% "scalatest" % "1.9.1"

--- a/scalatest/src/main/scala/jetty/Served.scala
+++ b/scalatest/src/main/scala/jetty/Served.scala
@@ -1,21 +1,22 @@
 package unfiltered.scalatest.jetty
 
-import _root_.unfiltered.scalatest.Hosted
+import unfiltered.scalatest.Hosted
 import org.scalatest.FeatureSpec
 
 trait Served extends FeatureSpec with Hosted {
 
   import unfiltered.jetty._
   def setup: (Server => Server)
-  lazy val server = setup(Http(port))
+  def getServer = setup(Http(port))
 
   override protected def withFixture(test: NoArgTest) {
-    server.start();
+    val server = getServer
+    server.start()
     try {
-          test() // Invoke the test function
+      test() // Invoke the test function
     } finally {
-      server.stop();
-      server.destroy();
+      server.stop()
+      server.destroy()
     }
   }
 }

--- a/scalatest/src/main/scala/netty/Served.scala
+++ b/scalatest/src/main/scala/netty/Served.scala
@@ -1,21 +1,22 @@
 package unfiltered.scalatest.netty
 
-import _root_.unfiltered.scalatest.Hosted
-import org.scalatest.fixture.FixtureFeatureSpec
+import unfiltered.scalatest.Hosted
+import org.scalatest.fixture.FeatureSpec
 
+trait Served extends FeatureSpec with Hosted {
 
-trait Served extends FixtureFeatureSpec with Hosted {
   import unfiltered.netty._
   def setup: (Int => Server)
-  lazy val server = setup(port)
+  def getServer = setup(port)
 
   override protected def withFixture(test: NoArgTest) {
-    server.start();
+    val server = getServer
+    server.start()
     try {
       test() // Invoke the test function
     } finally {
-      server.stop();
-      server.destroy();
+      server.stop()
+      server.destroy()
     }
   }
 }


### PR DESCRIPTION
and no scalatest version gymnast...ics (1.9.1 across the board).

I'm not sure what kind of use this module sees, and I'm a bit new to Scalatest, but the current trait would fail all examples uses I've seen as it tries to reuse the server reference. This change hands out a fresh server via withFixture for each run; setups/teardowns included.
