### PR TITLE
Send channelOpen event upstream

### DIFF
--- a/netty-server/src/main/scala/servers.scala
+++ b/netty-server/src/main/scala/servers.scala
@@ -146,6 +146,7 @@ class HouseKeepingChannelHandler(channels: ChannelGroup) extends SimpleChannelUp
   override def channelOpen(ctx: ChannelHandlerContext, e: ChannelStateEvent) = {
     // Channels are automatically removed from the group on close
     channels.add(e.getChannel)
+    ctx.sendUpstream(e)
   }
 }
 


### PR DESCRIPTION
Some handlers (namely ReadTimeoutHandler) expect channelOpen events to perform initialization. Consuming an event here causes incorrect behavior in such handlers.
