### PR TITLE
affirmed directives

### DIFF
--- a/directives/src/main/scala/directives/Directive.scala
+++ b/directives/src/main/scala/directives/Directive.scala
@@ -11,6 +11,11 @@ object Directive {
   def apply[T, R, A](run:HttpRequest[T] => Result[R, A]):Directive[T, R, A] =
     new Directive[T, R, A](run)
 
+  /** Produces a Directive with the given Result.Success value, for when a directive
+   *  is required to satisfy an intent's interface but all requests are acceptable */
+  def success[A,B](runSuccess: => B) =
+    Directive[A, Nothing, B]({ (_: HttpRequest[A]) => Success(runSuccess) })
+
   trait Fail[-T, +R, +A]{
     def map[X](f:R => X):Directive[T, X, A]
     def ~> [RR, TT <: T, AA >: A](and: ResponseFunction[RR])

--- a/directives/src/main/scala/directives/Directives.scala
+++ b/directives/src/main/scala/directives/Directives.scala
@@ -46,10 +46,6 @@ trait Directives {
     def orElse[R](fail:ResponseFunction[R]) = Directive[Any, ResponseFunction[R], A](r => if(f.isDefinedAt(r)) Success(f(r)) else Failure(fail))
   }
 
-  /** produces a directive that will always be a success and may be used in cases where a directive
-   *  is required to satisfy an intent's interface but no validation is needed */
-  def affirmed[A,B](result: => B) = Directive[A, Nothing, B]({ (_: HttpRequest[A]) => Success(result) })
-
   def request[T] = Directive[T, Nothing, HttpRequest[T]](Success(_))
 
   def underlying[T] = request[T] map { _.underlying }

--- a/directives/src/test/scala/DirectivesSpec.scala
+++ b/directives/src/test/scala/DirectivesSpec.scala
@@ -54,7 +54,7 @@ trait DirectivesSpec extends unfiltered.spec.Hosted {
 
   def intent[A,B] = Directive.Intent.Path {
     case "/affirmation" =>
-      affirmed {
+      Directive.success {
         ResponseString("this request needs no validation")
       }
     case "/commit_or" =>

--- a/notes/0.7.1.markdown
+++ b/notes/0.7.1.markdown
@@ -15,7 +15,8 @@ This allows you to mix external input into parameter interpreting directives
             .named("explicit_value", Some(YourType(a)).filter(predicate)))
     } yield ...
 
-* [PR 186][186] **Added new affirmed directive** useful in directive contexts that need no validation
+* [PR 186][186] **Added Directive.success**, useful in directive
+  contexts where all requests are accepted
 
 [180]: https://github.com/unfiltered/unfiltered/pull/180
 [181]: https://github.com/unfiltered/unfiltered/pull/181


### PR DESCRIPTION
Ran into this need a few times. Sometimes you are exposing information in a context that requires a directive validation signature but a specific case may need no actual validation. I think it would be good to attach a name to this this as well as method that helps satisfy the context's interface.
