### PR TITLE
Feature/faster cookies #scala-bug-bash

### DIFF
--- a/library/src/main/scala/response/cookies.scala
+++ b/library/src/main/scala/response/cookies.scala
@@ -33,7 +33,7 @@ object ToCookies {
     if (!res.isEmpty) {
       res.setLength(res.length - 1)
       res.toString
-    } else res.toString()
+    } else res.toString
   }
 
   private def escape(s: String) = s match {


### PR DESCRIPTION
This PR makes cookie serialization significantly faster by 1) stop using `String.format` and 2) a Regex for detecting characters that need quoting. It also cleans up the use of `map` vs `foreach` when side-effecting.
