### PR TITLE
Fixed an issue in MIME type parsing that would cause it to fail whenever...

### DIFF
--- a/util/src/main/scala/mime.scala
+++ b/util/src/main/scala/mime.scala
@@ -27,7 +27,7 @@ object MIMEType {
       val names = mimeType.getParameters.getNames
       val params = names.foldLeft(Map.empty[String, String]) {
         case (acc, p: String) =>
-          acc + (p -> mimeType.getParameter(p.asInstanceOf))
+          acc + (p -> mimeType.getParameter(p))
       }
       new MIMEType(mimeType.getPrimaryType, mimeType.getSubType, params)
     }


### PR DESCRIPTION
Calling `asInstanceOf` (without a type parameter) on an instance of `String` will always fail, since instances of `String` cannot be cast to instances of `Nothing`.

This caused MIME type parsing to fail whenever a MIME type contained a parameter (such as `charset=utf-8`, for example).

Removing the offending call seems to fix the issue.
