### PR TITLE
Updated specs2 section in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,9 +32,9 @@ Binds the core library to a Netty channel handler and provides an embedded serve
 
 Provides extractors for multipart posts using netty.
 
-### spec
+### specs2
 
-Provides helpers for testing Intents with [specs](http://code.google.com/p/specs/).
+Provides helpers for testing Intents with [specs2](http://etorreborre.github.io/specs2/).
 
 ### uploads
 


### PR DESCRIPTION
Updated README doc. The unfiltered module supporting specs2 is now called `specs2` instead of `specs`.

Also, there is a similarly outdated line in the docs at http://unfiltered.databinder.net/Combined+Pages.html#Project+Setup. Is there somewhere I can go to submit a PR to update that?

Specifically, those docs suggest that `unfiltered-spec_2.11.0` is the correct artifact name. But really it is `unfiltered-specs2_2.11.0`.

Thanks.
