### PR TITLE
send a LastHttpContent marker after a ChunkedStream

### DIFF
--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -135,10 +135,10 @@ case class Resources(
                           raf, 0, len, 8192/*ChunkedStream.DEFAULT_CHUNK_SIZE*/)
                       else new DefaultFileRegion(raf.getChannel, 0, len))
 
-                    lastly(ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT))
                   case other =>
-                    ctx.writeAndFlush(new ChunkedStream(other.in))
+                    ctx.write(new ChunkedStream(other.in))
                 }
+                lastly(ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT))
               } else lastly(writeHeaders) // HEAD request
             } catch {
               case e: FileNotFoundException =>


### PR DESCRIPTION
In case a resource was not a FileSystemResource, the HTTP response was
not correctly terminated, which - when using HTTP/1.1 keepAlive -
resulted in the following exception to be thrown for the next request:

```
could not write header io.netty.handler.codec.EncoderException:
  java.lang.IllegalStateException: unexpected message type: DefaultHttpResponse
  ...
Caused by:
  java.lang.IllegalStateException: unexpected message type: DefaultHttpResponse
```
