### PR TITLE
compare last modified times using 1 second resolution

### DIFF
--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -18,6 +18,7 @@ import java.io.{ File, FileNotFoundException, RandomAccessFile }
 import java.net.{ URL, URLDecoder }
 import java.text.SimpleDateFormat
 import java.util.{ Calendar, GregorianCalendar }
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.activation.MimetypesFileTypeMap
 
 import scala.util.control.Exception.allCatch
@@ -76,8 +77,11 @@ case class Resources(
     case Retrieval(Path(path)) & req => safe(path.drop(1)) match {
       case Some(rsrc) =>
         val ctx = req.underlying.context
+        def ms_to_s(t: Long) = MILLISECONDS.toSeconds(t)
         IfModifiedSince(req) match {
-          case Some(since) if (since.getTime == rsrc.lastModified) =>
+          // compare using 1 second resolution because that's the
+          // precision of the time format in the IfModifiedSince header
+          case Some(since) if (ms_to_s(since.getTime) == ms_to_s(rsrc.lastModified)) =>
             // close immediately and do not include content-length header
             // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
             ctx.write(


### PR DESCRIPTION
Since the time formats used in the If-Modified-Since header do
only have seconds, comparing it to a file's last modification
time will fail when the filesystem has a higher resolution.

Although modern file system like ext4 and btrfs have nanosecond
timestamp resolution, the java.io.File#lastModified method just
returns timestamps with a resolution of 1 second on Linux.

See http://bugs.java.com/view_bug.do?bug_id=6939260

In contrast, on MS Windows with NTFS, the last ResourceSpec test
was indeed failing because the JVM uses a higher resolution here.
