### PR TITLE
flush out HTTP headers for 304 responses

### DIFF
--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -102,7 +102,7 @@ case class Resources(
               NotModified ~>
               Date(Dates.format(new GregorianCalendar().getTime)))
 
-            lastly(ctx.write(req.underlying.defaultResponse(headers)))
+            lastly(ctx.writeAndFlush(req.underlying.defaultResponse(headers)))
 
           case _ =>
             if (!rsrc.exists || rsrc.hidden) notFound(req)


### PR DESCRIPTION
This fixes a regression introduced in b17c29d504513686 because if the
connection is kept alive, the data transfer might stall when not calling
flush.
