### PR TITLE
Support X-Forwarded-Proto and X-Forwarded-Port

### DIFF
--- a/library/src/main/scala/request/headers.scala
+++ b/library/src/main/scala/request/headers.scala
@@ -173,6 +173,8 @@ object Upgrade extends RepeatableHeader("Upgrade")
 object UserAgent extends StringHeader("User-Agent")// maybe a bit more structure here
 object Via extends RepeatableHeader("Via")
 object XForwardedFor extends RepeatableHeader("X-Forwarded-For")
+object XForwardedPort extends IntHeader("X-Forwarded-Port")
+object XForwardedProto extends StringHeader("X-Forwarded-Proto")
 
 /** Extracts the charset value from the Content-Type header, if present */
 object Charset {


### PR DESCRIPTION
When behind proxies, sometimes the proxies terminates SSL
connections. When we are generating links, we want to be able to
create a sane link using the same port and schemes as the reverse
proxy wants, meaning we need to look at X-Forwarded-Proto and maybe
X-Forwarded-Port.

This commit adds both, and uses X-Forwarded-Port in the HostPort
extractor.
