### PR TITLE
cycle and async plans should push websocket frames through the pipeline

### DIFF
--- a/netty/src/main/scala/async/plans.scala
+++ b/netty/src/main/scala/async/plans.scala
@@ -49,6 +49,7 @@ trait RequestPlan extends ChannelInboundHandlerAdapter with ExceptionHandler {
       }
       // fixme(doug): I don't think this will ever be the case as we are now always adding the aggregator to the pipeline
       case chunk: HttpContent => ctx.fireChannelRead(chunk)
+      case frame: WebSocketFrame => ctx.fireChannelRead(frame)
       // fixme(doug): Should we define an explicit exception to catch for this
       case ue => sys.error("Unexpected message type from upstream: %s"
                            .format(ue))

--- a/netty/src/main/scala/cycle/plans.scala
+++ b/netty/src/main/scala/cycle/plans.scala
@@ -6,6 +6,7 @@ import io.netty.handler.codec.http.{
   HttpContent,
   HttpRequest => NettyHttpRequest,
   HttpResponse }
+import io.netty.handler.codec.http.websocketx.WebSocketFrame
 import io.netty.channel.{ ChannelHandlerContext, ChannelInboundHandlerAdapter }
 import io.netty.channel.ChannelHandler.Sharable
 
@@ -73,8 +74,8 @@ trait Plan extends ChannelInboundHandlerAdapter
           }
         }
       // fixme(doug): I don't think this will ever be the case as we are now always adding the aggregator to the pipeline
-      case chunk: HttpContent =>
-        ctx.fireChannelRead(chunk)
+      case chunk: HttpContent => ctx.fireChannelRead(chunk)
+      case frame: WebSocketFrame => ctx.fireChannelRead(frame)
       // fixme(doug): Should we define an explicit exception to catch for this
       case ue => sys.error("Received unexpected message type from upstream: %s"
                            .format(ue))


### PR DESCRIPTION
Given the following websocket and http plans:

``` scala
@Sharable
object WebSocketFoo extends Plan
with cycle.SynchronousExecution with ServerErrorResponse {
  def intent = {
    case GET(Path("/")) => {
      case Open(s) => println("open! " + s)
      case Message(s, Text(t)) => println(s"message from $s: $t")
      case Close(s) => println(s"close! $s")
      case Error(s, e) => println(s"error! $s")
    }
  }

  def pass = DefaultPassHandler
}

@Sharable
object HttpFoo extends cycle.Plan with cycle.SynchronousExecution with ServerErrorResponse {
  def intent = {
    case GET(Path("/hi")) => Ok ~> ResponseString("Hello")
  }
}
```

The following server will throw exceptions when when it receives websocket frames:

``` scala
object Server {
  def main(args: Array[String]) {
    unfiltered.netty.Http(8080)
      .handler(HttpFoo)
      .handler(WebSocketFoo)
      .run { s =>
        println("starting unfiltered app at localhost on port %s"
          .format(s.port))
      }
  }
}
```

While this one will work as expected:

``` scala
object Server {
  def main(args: Array[String]) {
    unfiltered.netty.Http(8080)
      .handler(WebSocketFoo)
      .handler(HttpFoo)
      .run { s =>
        println("starting unfiltered app at localhost on port %s"
          .format(s.port))
      }
  }
}
```

This is because the netty http plans pessimistically fail through `sys.error` when a non-http message is received, thus introducing an unnecessary and unintuitive order dependency in servers that service both http and websocket requests. This change results in the plans optimistically pushing websocket frames through the pipeline if received.
