### PR TITLE
Continue to use GlobalEventExecutor as default in netty-server.

### DIFF
--- a/netty-server/src/main/scala/Engine.scala
+++ b/netty-server/src/main/scala/Engine.scala
@@ -3,7 +3,7 @@ package unfiltered.netty
 import io.netty.channel.EventLoopGroup
 import io.netty.channel.group.{ ChannelGroup, DefaultChannelGroup }
 import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.util.concurrent.ImmediateEventExecutor
+import io.netty.util.concurrent.{EventExecutor, GlobalEventExecutor}
 
 /** Defines the set of resources used for process scheduling
  *  and collecting active channels needed for graceful shutdown */
@@ -20,10 +20,10 @@ object Engine {
   object Default extends Engine {
     def acceptor = new NioEventLoopGroup()
     def workers = new NioEventLoopGroup()
-    def channels = new DefaultChannelGroup(
-      "Netty Unfiltered Server Channel Group",
-      ImmediateEventExecutor.INSTANCE)
+    def channels = defaultChannels(GlobalEventExecutor.INSTANCE)
   }
+  private [Engine] def defaultChannels(executor: EventExecutor) =
+    new DefaultChannelGroup("Netty Unfiltered Server Channel Group", executor)
 
   /** An interface building netty server engines */
   trait Builder[T] {
@@ -51,5 +51,9 @@ object Engine {
       lazy val workers = engine.workers
       lazy val channels = group
     })
+
+    /** Sets channels to a DefaultChannelGroup using the given executor */
+    def channelsExecutor(executor: EventExecutor) =
+      channels(defaultChannels(executor))
   }
 }


### PR DESCRIPTION
I brought this up as a comment in the dropped pr #240 but forgot to
circle back to it in #242.

I wasn't convinced that `GlobalEventExecutor` is a bad default, and
I'm pretty sure that `ImmediateEventExecutor` "which executes tasks in
the callers thread" is a worse one. As mentioned in this
[stackoverflow thread](http://stackoverflow.com/a/18072390) which suggests that GEE is a reasonable
choice, this executor is used "to notify the ChannelGroupFutures". I
don't think it's a good idea to block the calling thread to do that.

We aren't limited to the 3 executors included with Netty but among
those `GlobalEventExecutor` seems to be the most appropriate. For now
let's stick with that. With the refactoring, anybody can supply their
own executor and I'm making that a little easier here
too (`channelsExecutor` builder method).
