### PR TITLE
Docs - netty-server section: add missing method call on Server

### DIFF
--- a/docs/03.markdown
+++ b/docs/03.markdown
@@ -91,5 +91,5 @@ import unfiltered.response._
 val hello = unfiltered.netty.cycle.Planify {
   case _ => ResponseString("hello world")
 }
-unfiltered.netty.Server(8080).plan(hello).run()
+unfiltered.netty.Server.local(8080).plan(hello).run()
 ```


### PR DESCRIPTION
The current `unfiltered.netty.Server(8080).plan(hello).run()` returns

```
error: not enough arguments for method apply: (portBindings: List[unfiltered.netty.PortBinding], handlers: List[() => io.netty.channel.ChannelHandler], beforeStopBlock: () => Unit, chunkSize: Int, engine: unfiltered.netty.Engine)unfiltered.netty.Server in object Server.
Unspecified value parameters handlers, beforeStopBlock, chunkSize, ...
```

The proposed change will properly start the server on `http://127.0.0.1:8080`.
