### PR TITLE
Updated netty-websockets readme

### DIFF
--- a/docs/10/a.markdown
+++ b/docs/10/a.markdown
@@ -24,7 +24,7 @@ import unfiltered.response._
 val hello = unfiltered.netty.cycle.Planify {
    case _ => ResponseString("hello world")
 }
-unfiltered.netty.Server(8080).plan(hello).run()
+unfiltered.netty.Server.http(8080).plan(hello).run()
 ```
 
 Direct a web browser to [http://127.0.0.1:8080/][local] and you'll

--- a/netty-websockets/README.md
+++ b/netty-websockets/README.md
@@ -27,7 +27,7 @@ The above example is equivalent to a handler of the format
      netty.websockets.Planify({
        case GET(Path("/")) => {
          case Open(socket) => ...
-         case Message(s, Text(str) => ..
+         case Message(s, Text(str)) => ..
          ...
        }
     })
@@ -60,7 +60,7 @@ An example of a subscription based service where clients receive msgs as they ar
 
 To mix in websockets in with a Netty HTTP server, use the full `Plan.Intent` function to build a `Plan` with `Planify`
 
-    netty.Http(8080)
+    netty.Server.http(8080)
        .handler(netty.websockets.Planify({
           case Path("/foo") => {
              case Open(socket) =>


### PR DESCRIPTION
Code examples still have the `0.7.X` code in them.

The main example is outdated as well, but I couldn't come up with a decent replacement.
