### PR TITLE
Update to Netty 4.1 and make it possible to provide a custom HttpObjectAggregator

### DIFF
--- a/netty-server/src/main/scala/Chunker.scala
+++ b/netty-server/src/main/scala/Chunker.scala
@@ -1,0 +1,88 @@
+package unfiltered.netty
+
+import io.netty.channel.{
+  ChannelFutureListener,
+  ChannelHandlerContext,
+  ChannelFuture
+}
+import io.netty.channel.ChannelHandler.Sharable
+
+import io.netty.handler.codec.{
+  TooLongFrameException
+}
+
+import io.netty.handler.codec.http.{
+  DefaultHttpResponse, DefaultFullHttpResponse, HttpContent, HttpMessage, HttpResponseStatus, 
+  HttpObjectAggregator, HttpResponse, HttpVersion, HttpRequest, FullHttpMessage, HttpObjectDecoder
+}
+
+import io.netty.buffer.Unpooled
+import io.netty.handler.codec.http.HttpHeaders
+import io.netty.handler.codec.http.HttpHeaders.Names._
+import io.netty.handler.codec.http.HttpHeaders.Values._
+
+/** Provide a simple way to provide a custom HttpObjectAggregator implementation to the Server.
+ *  You may want to do this if for example you need to send an informative error message along 
+ *  with a 413 status if the request is too large. */
+@Sharable
+class Chunker(size: Int) extends HttpObjectAggregator(size)
+
+/** Allows sending a response body along with the 413 response */
+class PoliteChunker(size: Int, responseBody: String, contentType: String = "text/plain") extends Chunker(size) {
+
+  /** Send a 413 status and a custom response body */
+  override def handleOversizedMessage(ctx: ChannelHandlerContext, oversized: HttpMessage) = oversized match {
+
+    case _: HttpRequest =>
+
+      val body = responseBody.getBytes("utf-8")
+      val contentLength = body.size
+      val tooLarge = new DefaultFullHttpResponse(
+        HttpVersion.HTTP_1_1, 
+        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, 
+        Unpooled.copiedBuffer(body))
+      tooLarge.headers().set(CONTENT_LENGTH, contentLength)
+    
+      // send back a 413 and close the connection
+      val future = ctx.writeAndFlush(tooLarge).addListener(new ChannelFutureListener() {
+        def operationComplete(future: ChannelFuture) {
+          if (!future.isSuccess()) {
+            System.err.println("Failed to send a 413 Request Entity Too Large. " + future.cause())
+            ctx.close()
+          }
+        }
+      })
+
+      // If the client started to send data already, close because it's impossible to recover.
+      // If 'Expect: 100-continue' and keep-alive is off, no need to leave the connection open.
+      if (oversized.isInstanceOf[FullHttpMessage] ||
+              (!HttpHeaders.is100ContinueExpected(oversized) && !HttpHeaders.isKeepAlive(oversized))) {
+        future.addListener(ChannelFutureListener.CLOSE)
+      }
+
+      // If an oversized request was handled properly and the connection is still alive
+      // (i.e. rejected 100-continue). the decoder should prepare to handle a new message.
+      if (HttpHeaders.is100ContinueExpected(oversized)) {
+        Option(ctx.pipeline().get(classOf[HttpObjectDecoder])).map { 
+          _.reset()
+        }
+      }
+    
+    case _: HttpResponse =>
+      ctx.close();
+      throw new TooLongFrameException("Response entity too large: " + oversized)
+    
+    case _ =>
+      throw new IllegalStateException()
+  }
+}
+
+/** Chunker factory for helping make Chunkers */
+object Chunker {
+  def apply(size: Int) = () => new Chunker(size)
+
+  object Polite {
+    def apply(size: Int, responseBody: String, contentType: String = "text/plain") = 
+      () => new PoliteChunker(size, responseBody, contentType)
+  }
+}

--- a/netty-server/src/main/scala/NotFoundHandler.scala
+++ b/netty-server/src/main/scala/NotFoundHandler.scala
@@ -19,7 +19,7 @@ class NotFoundHandler
     (msg match {
       case req: HttpMessage =>
         ReferenceCountUtil.release(req)
-        Some(req.getProtocolVersion)
+        Some(req.protocolVersion)
         // fixme(doug): this may no be unessessary
       case chunk: HttpContent =>
         ReferenceCountUtil.release(chunk)

--- a/netty-uploads/src/main/scala/request/decoder.scala
+++ b/netty-uploads/src/main/scala/request/decoder.scala
@@ -30,9 +30,6 @@ class PostDecoder(req: HttpRequest, useDisk: Boolean = true) {
       /** Would it be more useful to throw errors here? */
       case e: HttpPostRequestDecoder.ErrorDataDecoderException =>
         None
-      /** GET method. Can't create a decoder. */
-      case e: HttpPostRequestDecoder.IncompatibleDataDecoderException =>
-        None
     }
 
   /** Whether the request is multi-part */

--- a/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
+++ b/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
@@ -94,7 +94,7 @@ object NoChunkAggregatorSpec extends Specification
 
     // note(doug): in netty3 versions of unfiltered this would result in a 500 error
     "respond with a 200 when no chunk aggregator is used in a cycle plan" in {
-      val http = new dispatch.classic.Http with NoLogging
+      val http = new dispatch.classic.Http //with NoLogging
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
       try {

--- a/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
+++ b/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
@@ -94,7 +94,7 @@ object NoChunkAggregatorSpec extends Specification
 
     // note(doug): in netty3 versions of unfiltered this would result in a 500 error
     "respond with a 200 when no chunk aggregator is used in a cycle plan" in {
-      val http = new dispatch.classic.Http //with NoLogging
+      val http = new dispatch.classic.Http with NoLogging
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
       try {

--- a/netty/build.sbt
+++ b/netty/build.sbt
@@ -4,6 +4,6 @@ unmanagedClasspath in (local("netty"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(v =>
-  ("io.netty" % "netty-codec-http" % "4.0.23.Final") +:
+  ("io.netty" % "netty-codec-http" % "4.1.0.Beta3") +:
   Common.integrationTestDeps(v)
 )

--- a/netty/src/main/scala/bindings.scala
+++ b/netty/src/main/scala/bindings.scala
@@ -39,7 +39,7 @@ class RequestBinding(msg: ReceivedMessage)
 
   private[this] lazy val params = queryParams ++ bodyParams
 
-  private def queryParams = req.getUri.split("\\?", 2) match {
+  private def queryParams = req.uri.split("\\?", 2) match {
     case Array(_, qs) => URLParser.urldecode(qs)
     case _ => Map.empty[String,Seq[String]]
   }
@@ -62,12 +62,12 @@ class RequestBinding(msg: ReceivedMessage)
   lazy val reader =
     new BufferedReader(new InputStreamReader(inputStream, charset))
 
-  def protocol = req.getProtocolVersion.text()
+  def protocol = req.protocolVersion.text()
 
-  def method = req.getMethod.toString.toUpperCase
+  def method = req.method.toString.toUpperCase
 
   // todo should we call URLDecoder.decode(uri, charset) on this here?
-  def uri = req.getUri
+  def uri = req.uri
 
   def parameterNames = params.keySet.iterator
 
@@ -163,7 +163,7 @@ class ResponseBinding[U <: NettyHttpResponse](res: U)
     res.setStatus(HttpResponseStatus.valueOf(code))
 
   def status: Int =
-    res.getStatus.code()
+    res.status.code()
 
   def header(name: String, value: String) =
     res.headers.add(name, value)


### PR DESCRIPTION
I ran in to some issues in my project caused by the chunk aggregator now being included in the Netty pipeline by default. 

On it's own that wasn't such a big deal, but with the `HttpObjectAggregator` in Netty 4.0.23 I couldn't find a way to respond to an oversize request with a 413 status _and_ an error message in the body _and_ cleanly close the request without a broken pipe. Maybe I missed something.

Anyhow I ended up looking in to Netty 4.1 which adds the ability to provide a custom handler for oversize requests, but this requires a custom `HttpObjectAggregator` instance. So I thought it might be useful to make that possible in the `unfiltered.netty.Server` somehow, so here's my suggestion. 

It might not be a great plan to update to to Netty 4.1.0-Beta3 just yet, but it would be great to get your feedback in any case.

There is one breaking change here, as I have swapped out the `chunkSize: Int` parameter to `Server` for `chunker: () => Chunker` instead. Maybe there's a better way to do it.
