### PR TITLE
ContextAdder support for specifying aliases flag on ContextHandler

### DIFF
--- a/jetty/src/main/scala/contexts.scala
+++ b/jetty/src/main/scala/contexts.scala
@@ -13,12 +13,14 @@ trait ContextAdder {
   @deprecated("Use `plan(filter)`", "0.8.1")
   def filter(filter: Filter) = plan(filter)
   def resources(path: java.net.URL): ContextAdder
+  def allowAliases(aliases: Boolean): ContextAdder
 }
 
 case class DefaultServletContextAdder(
   path: String,
   filterAdders: List[FilterAdder],
-  resourcePath: Option[java.net.URL]
+  resourcePath: Option[java.net.URL],
+  aliases: Boolean = false
 ) extends ContextAdder {
   def addToParent(parent: ContextHandlerCollection) = {
     val ctx = new ServletContextHandler(parent, path, false, false)
@@ -31,9 +33,13 @@ case class DefaultServletContextAdder(
 
     for (path <- resourcePath)
       ctx.setBaseResource(Resource.newResource(path))
+
+    ctx.setAliases(aliases)
   }
 
   def filterAdder(filter: FilterAdder) = copy(filterAdders = filter :: filterAdders)
 
   def resources(path: java.net.URL) = copy(resourcePath = Some(path))
+
+  def allowAliases(aliases: Boolean) = copy(aliases = aliases)
 }


### PR DESCRIPTION
Use case: I use Unfiltered both to drive a backend API and to serve Scala.js content from a peer directory. I.e. I wanted to serve resources from a relative path like:

``` scala
unfiltered.jetty.Server.http(8080).
      context("/client"){ ctx: ContextAdder =>
      ctx.resources(new java.net.URL(
        """file:../mg-client"""
      )).allowAliases(true)
      }.filter(api).run()
```

Initially, the resources 404ed. Debugging revealed the reason is that `../mg-client` is considered an /aliased/ path since it's non-canonical, and runs afoul of this default policy: http://www.eclipse.org/jetty/documentation/current/serving-aliased-files.html

This PR gives users of unfiltered-jetty a way to opt out of this strict policy, which is undesirable/unnecessary in my case. I'd expect the ability to serve resources off relative paths that include parent dirs would be useful to many Unfiltered users.

One downside is that existing user-implementations of `ContextAdder` will no longer compile, since new abstract method is added. However, it wasn't clear that this trait is intended to be extended by users of Unfiltered.
