### PR TITLE
FilterDirective fixes

### DIFF
--- a/directives/src/main/scala/directives/Directive.scala
+++ b/directives/src/main/scala/directives/Directive.scala
@@ -104,6 +104,7 @@ class FilterDirective[-T, +R, +A](
   run: HttpRequest[T] => Result[R, A],
   onEmpty: HttpRequest[T] => Result[R, A]
 ) extends Directive[T,R,A](run) {
+  def filter(filt: A => Boolean): Directive[T, R, A] = withFilter(filt)
   def withFilter(filt: A => Boolean): Directive[T, R, A] =
     new FilterDirective({ req =>
       run(req).flatMap { a =>


### PR DESCRIPTION
Some things that fell through the cracks when I added `if` support in the last release: this fixes the return type for the general `Directive#orElse` method so that filtering is available, and this also adds the expected `filter` alias for when you're not in a for expression.
