### PR TITLE
New feature: Jetty supports global request logging

### DIFF
--- a/jetty/src/main/scala/logging.scala
+++ b/jetty/src/main/scala/logging.scala
@@ -1,0 +1,9 @@
+package unfiltered.jetty
+
+case class RequestLogging(
+  filename: String,
+  extended: Boolean,
+  dateFormat: String,
+  timezone: String,
+  retainDays: Int
+)


### PR DESCRIPTION
Support for [http://www.eclipse.org/jetty/documentation/current/configuring-jetty-request-logs.html] in what I hope is an idiomatic unfiltered style. Tested manually on my own unfiltered app.
