### PR TITLE
Browser.open should agree with its documentation & prior behavior.

### DIFF
--- a/util/src/main/scala/utils.scala
+++ b/util/src/main/scala/utils.scala
@@ -16,9 +16,12 @@ object Port {
 object Browser {
   /** Tries to open a web browser session, returns Some(exception) on failure */
   def open(loc: String) =
-    util.Try(
+    try {
       java.awt.Desktop.getDesktop.browse(new java.net.URI(loc))
-    ).toOption
+      None
+    } catch {
+      case NonFatal(e) => Some(e)
+    }
 }
 
 /** Extractors that match on strings that can be converted to types. */


### PR DESCRIPTION
My bad! Also, going back to old fashioned exception handling because
`Try` is weak.  https://issues.scala-lang.org/browse/SI-8336
