### PR TITLE
update to latest version of netty

### DIFF
--- a/netty/build.sbt
+++ b/netty/build.sbt
@@ -4,6 +4,6 @@ unmanagedClasspath in (local("netty"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(v =>
-  ("io.netty" % "netty-codec-http" % "4.0.23.Final") +:
+  ("io.netty" % "netty-codec-http" % "4.0.24.Final") +:
   Common.integrationTestDeps(v)
 )


### PR DESCRIPTION
upgrades to the latest [stable](http://netty.io/news/2014/10/29/4-0-24-Final.html) version of netty, released yesterday.
