### PR TITLE
fileupload dependency bump, with FileItemHeaders-support

### DIFF
--- a/filter-uploads/build.sbt
+++ b/filter-uploads/build.sbt
@@ -5,5 +5,5 @@ unmanagedClasspath in (local("filter-uploads"), Test) <++=
 
 libraryDependencies <++= scalaVersion(v => Seq(
   Common.servletApiDep,
-  "commons-fileupload" % "commons-fileupload" % "1.2.1"
+  "commons-fileupload" % "commons-fileupload" % "1.3.1"
 ) ++ Common.integrationTestDeps(v))

--- a/uploads/build.sbt
+++ b/uploads/build.sbt
@@ -4,5 +4,5 @@ unmanagedClasspath in (local("uploads"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(v => Seq(
-  "commons-io" % "commons-io" % "1.4"
+  "commons-io" % "commons-io" % "2.4"
 ) ++ Common.integrationTestDeps(v))


### PR DESCRIPTION
Mostly to shut sbt up about conflicting dependencies in a project I'm working on. 
I took the liberty of removing two casts which i couldn't understand the purpose of as well.

(I think all the tests still run green, on os x they don't shutdown cleanly)