### PR TITLE
Reposition ChunkedWriteHandler to fix resource serving failure.

### DIFF
--- a/netty-server/src/main/scala/Server.scala
+++ b/netty-server/src/main/scala/Server.scala
@@ -140,6 +140,6 @@ case class Server(
     cacheSeconds: Int   = 60,
     passOnFail: Boolean = true) = {
     val resources = Resources(path, cacheSeconds, passOnFail)
-    this.plan(resources).makePlan(new ChunkedWriteHandler)
+    this.makePlan(new ChunkedWriteHandler).plan(resources)
   }
 }


### PR DESCRIPTION
Through some testing (of Pamflet) I learned that serving of packaged
JAR resources was no longer working, apparently in all versions of
Unfiltered using Netty 4.

Tracing through the code in resources.scala, there are 3 ways
resources are served:

1. For a local file over HTTP, we write a DefaultFileRegion
object. Since the integration tests run against local files, this
method was tested and works.

2. For a local file over HTTPS, we write a ChunkedFile object. This
did not work, no content was written and the request was left open
indefinitely.

3. For resource that is not a local file, we write a ChunkedStream
object. This also did not work, it is the case that applies to a JAR
resource.

Through some trial and error I eventually discovered changing the
position of the ChunkedWriteHandler in the pipeline fixes the problem
for both the HTTPS and non-file cases.