### PR TITLE
Basing Body.string on stream instead of reader

### DIFF
--- a/library/src/main/scala/request/readers.scala
+++ b/library/src/main/scala/request/readers.scala
@@ -1,6 +1,7 @@
 package unfiltered.request
 
-import java.io.{InputStreamReader, Closeable}
+import java.io.InputStreamReader
+import unfiltered.util.IO
 
 import scala.io.Codec
 
@@ -22,7 +23,7 @@ object Body {
     bos.toByteArray
   }
   def string[T](req: HttpRequest[T])(implicit codec: Codec = Codec.UTF8) = {
-    loan(new InputStreamReader(req.inputStream, codec.charSet)) { reader =>
+    IO.use(new InputStreamReader(req.inputStream, codec.charSet)) { reader =>
       val writer = new java.io.StringWriter
       val ca = new Array[Char](4096)
       @scala.annotation.tailrec def read() {
@@ -33,10 +34,5 @@ object Body {
       read()
       writer.toString
     }
-  }
-  
-  def loan[C <: Closeable, B](c: => C)(f: (C) => B): B = {
-    val cached = c
-    try { f(cached) } finally { cached.close() }
   }
 }

--- a/library/src/test/scala/GzipSpec.scala
+++ b/library/src/test/scala/GzipSpec.scala
@@ -81,7 +81,7 @@ trait GZipSpec extends Specification with unfiltered.specs2.Hosted {
     "echo an zipped request" in {
       val msg = http((host / "echo")
         <:< Map("Content-Encoding" -> "gzip")
-        << bos.toByteArray as_str)
+        << ubos.toByteArray as_str)
       msg must_== expected
     }
     "pass an non-matching request" in {


### PR DESCRIPTION
To enable specifying charset in the Body utility. Wrapping stream in a loaner to swallow the possible exception. Rewrote test to run utf-8 since we're all better off making this default.
