### PR TITLE
Update Netty to latest 4.0.X.Final version (4.0.30.Final)

### DIFF
--- a/netty/build.sbt
+++ b/netty/build.sbt
@@ -4,6 +4,6 @@ unmanagedClasspath in (local("netty"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(v =>
-  ("io.netty" % "netty-codec-http" % "4.0.24.Final") +:
+  ("io.netty" % "netty-codec-http" % "4.0.30.Final") +:
   Common.integrationTestDeps(v)
 )


### PR DESCRIPTION
We've found an issue using Unfiltered and Nettty where a large sized header (lots of cookies) causes the server to temporarily stop responding.  The problem appears to be fixed by this issue in the Netty codebase: https://github.com/netty/netty/pull/3379

This change was included as part of the 4.0.26.Final release.


We're currently using Unfiltered version 0.8.4 which includes Netty 4.0.24.Final.

We've deployed a change to our production servers where we explicitly hardcode the version of Netty to the *latest* final version: 4.0.30.Final and it fixes the problem.

This updates Unfiltered Netty to use this version so we (and others) won't need the local workaround.