### PR TITLE
Remove unused jetty-continuation dependency

### DIFF
--- a/filter-async/build.sbt
+++ b/filter-async/build.sbt
@@ -3,8 +3,4 @@ description := "Server binding for Java Servlet 3.0 async filters"
 unmanagedClasspath in (local("filter-async"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
-libraryDependencies <++= scalaVersion { v => Seq(
-  Common.servletApiDep,
-  "org.eclipse.jetty" % "jetty-continuation" % Common.jettyVersion % "compile")
-}
-
+libraryDependencies += Common.servletApiDep

--- a/filter-async/src/main/scala/async/plans.scala
+++ b/filter-async/src/main/scala/async/plans.scala
@@ -1,7 +1,5 @@
 package unfiltered.filter.async
 
-import org.eclipse.jetty.continuation.ContinuationSupport
-import org.eclipse.jetty.continuation.Continuation
 import util._
 import unfiltered.filter.{AsyncBinding,RequestBinding,ResponseBinding}
 import unfiltered.response.{NotFound, Pass}


### PR DESCRIPTION
The changes in #285 removed the need for depending on jetty-continuation in filter-async, but the dependency was still declared in `build.sbt` and two unused imports were left in the code. This small change removes jetty-continuation completely.
