### PR TITLE
Add Logback support

### DIFF
--- a/jetty/build.sbt
+++ b/jetty/build.sbt
@@ -1,5 +1,6 @@
 description := "Jetty server embedding module"
 
 libraryDependencies := Seq(
+  "ch.qos.logback" % "logback-access" % "1.1.7",
   "org.eclipse.jetty" % "jetty-webapp" % Common.jettyVersion
 )

--- a/jetty/src/main/scala/Server.scala
+++ b/jetty/src/main/scala/Server.scala
@@ -81,7 +81,9 @@ case class Server(
     Some(FileRequestLogging(filename, extended, dateFormat, timezone, retainDays))
   })
 
-  /** Configure global logging of requests to a logfile using logbackConfig. */
+  /** Configure global logging of requests to a logfile using logbackConfig in the class path.
+    * If you do not provide the filename, default of logback-access.xml will be used
+    * [[http://logback.qos.ch/access.html]] */
   def logbackRequestLogging(logbackConfigFileName: String = "logback-access.xml") = copy(requestLogging = {
     Some(LogbackRequestLogging(logbackConfigFileName))
   })

--- a/jetty/src/main/scala/Server.scala
+++ b/jetty/src/main/scala/Server.scala
@@ -5,7 +5,6 @@ import unfiltered.util.{ PlanServer, RunnableServer }
 import javax.servlet.Filter
 
 import org.eclipse.jetty.server.handler.{ContextHandlerCollection, RequestLogHandler, HandlerCollection}
-
 /** Holds port bindings for selected ports and interfaces. The
   * PortBindings trait provides convenience methods for bindings. */
 case class Server(
@@ -48,11 +47,7 @@ case class Server(
       contextHandlers)(rl => {
       val handlers = new HandlerCollection()
       val requestLogHandler = new RequestLogHandler()
-      val requestLog = new NCSARequestLog(rl.filename)
-      requestLog.setRetainDays(rl.retainDays);
-      requestLog.setExtended(rl.extended);
-      requestLog.setLogTimeZone(rl.timezone);
-      requestLogHandler.setRequestLog(requestLog);
+      requestLogHandler.setRequestLog(rl.requestLog);
       handlers.setHandlers(Array(contextHandlers, requestLogHandler))
       handlers
     })
@@ -83,7 +78,12 @@ case class Server(
                      dateFormat: String = "dd/MMM/yyyy:HH:mm:ss Z",
                      timezone: String = "GMT",
                      retainDays: Int = 31) = copy(requestLogging = {
-    Some(RequestLogging(filename, extended, dateFormat, timezone, retainDays))
+    Some(FileRequestLogging(filename, extended, dateFormat, timezone, retainDays))
+  })
+
+  /** Configure global logging of requests to a logfile using logbackConfig. */
+  def logbackRequestLogging(logbackConfigFileName: String = "logback-access.xml") = copy(requestLogging = {
+    Some(LogbackRequestLogging(logbackConfigFileName))
   })
 
   /** Ports used by this server, reported by super-trait */

--- a/jetty/src/main/scala/logging.scala
+++ b/jetty/src/main/scala/logging.scala
@@ -1,9 +1,33 @@
 package unfiltered.jetty
 
-case class RequestLogging(
+import ch.qos.logback.access.jetty.RequestLogImpl
+import org.eclipse.jetty.server.{NCSARequestLog, RequestLog}
+
+trait RequestLogging {
+  def requestLog: RequestLog
+}
+
+case class FileRequestLogging (
   filename: String,
   extended: Boolean,
   dateFormat: String,
   timezone: String,
   retainDays: Int
-)
+) extends RequestLogging {
+  override def requestLog: RequestLog = {
+    val requestLog = new NCSARequestLog(filename)
+    requestLog.setRetainDays(retainDays);
+    requestLog.setExtended(extended);
+    requestLog.setLogTimeZone(timezone);
+    requestLog
+  }
+}
+
+case class LogbackRequestLogging(logbackConfigFileName: String) extends RequestLogging {
+  override def requestLog: RequestLog = {
+    val requestLog = new RequestLogImpl
+    requestLog.setResource(s"/$logbackConfigFileName")
+    requestLog.start()
+    requestLog
+  }
+}


### PR DESCRIPTION
Add ability to do jetty request logging using logback-access
This is good to have in clusters like AWS ECS so request log can be sent to stdout and it automagically appears in cloud watch.

I have done least intrusive way. Let me know if its ok
