### PR TITLE
Fix non closing test resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ project/plugins/project/
 .settings
 .cache
 upload-test-out.txt
+async-upload-test-out.txt

--- a/directives/src/test/scala/DirectivesSpec.scala
+++ b/directives/src/test/scala/DirectivesSpec.scala
@@ -127,10 +127,10 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
 
   "Directives commit" should {
     "respond with expected commited error" in {
-      httpx(host / "commit_or").code() must_== 400
+      httpx(host / "commit_or").code must_== 400
     }
     "try alternative when failing before commit" in {
-      http(req(host / "commit_or").POST("")).code() must_== 200
+      http(req(host / "commit_or").POST("")).code must_== 200
     }
   }
   "Directives" should {
@@ -155,16 +155,16 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
       val resp = httpx(req(host / "accept_json" / "123")
         //<:< Map("Content-Type" -> "application/json")
         POST(someJson, JSONContentType))
-      resp.code() must_== 406
+      resp.code must_== 406
     }
     "respond with unsupported media if content-type wrong" in {
       val resp = httpx((req(host / "accept_json" / "123")
         <:< Map("Accept" -> "application/json")).POST(someJson))
-      resp.code() must_== 415
+      resp.code must_== 415
     }
     "respond with 404 if not matching" in {
       val resp = httpx(req(host / "accept_other" / "123").POST(someJson))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
   }
   "Directives decorated" should {
@@ -178,13 +178,13 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
       val resp = httpx(req(host / "awesome_json" / "123")
         <:< Map("Accept" -> "application/json")
         POST(someJson))
-      resp.code() must_== 415
+      resp.code must_== 415
     }
     "respond with unsupported media if content-type missing" in {
       val resp = httpx(req (host / "awesome_json" / "123")
         <:< Map("Accept" -> "application/json")
         POST(someJson, null))
-      resp.code() must_== 415
+      resp.code must_== 415
     }
   }
   "Directives if filtering" should {
@@ -198,13 +198,13 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
       val resp = httpx(req(host / "if_json" / "123")
         <:< Map("Accept" -> "application/json")
         POST(someJson))
-      resp.code() must_== 415
+      resp.code must_== 415
     }
     "respond with unsupported media if content-type missing" in {
       val resp = httpx(req(host / "if_json" / "123")
         <:< Map("Accept" -> "application/json")
         POST(someJson, null))
-      resp.code() must_== 415
+      resp.code must_== 415
     }
   }
   "Directive parameters" should {
@@ -231,8 +231,8 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
           "require_int" -> 4.toString,
           "even_int" -> 7.toString
         ))
-      resp.code() must_== 400
-      resp.body().string() must_== "even_int is not even: 7"
+      resp.code must_== 400
+      resp.as_string must_== "even_int is not even: 7"
     }
     "fail if int format is wrong" in {
       val resp = httpx(req(host / "valid_parameters")
@@ -240,16 +240,16 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
           "require_int" -> 4.toString,
           "even_int" -> "eight"
         ))
-      resp.code() must_== 400
-      resp.body().string() must_== "even_int is not an int: eight"
+      resp.code must_== 400
+      resp.as_string must_== "even_int is not an int: eight"
     }
     "fail if required parameter is missing" in {
       val resp = httpx(req(host / "valid_parameters")
         << Map(
           "require_int" -> 4.toString
         ))
-      resp.code() must_== 400
-      resp.body().string() must_== "even_int is missing"
+      resp.code must_== 400
+      resp.as_string must_== "even_int is missing"
     }
   }
   "Directive independent parameters" should {
@@ -268,8 +268,8 @@ trait DirectivesSpec extends SpecificationLike with unfiltered.specs2.Hosted {
           "option_int" -> "four",
           "even_int" -> 7.toString
         ))
-      resp.code() must_== 400
-      resp.body().string() must_== """option_int is not an int: four
+      resp.code must_== 400
+      resp.as_string must_== """option_int is not an int: four
 require_int is missing
 even_int is not even: 7"""
     }

--- a/json4s/src/test/scala/JsonSpec.scala
+++ b/json4s/src/test/scala/JsonSpec.scala
@@ -21,10 +21,10 @@ object JsonSpec extends Specification  with unfiltered.specs2.jetty.Served {
   "Json Response should" should {
     "produce a json response" in {
       val resp = http(req(host) <:< Map("Accept" -> "application/json"))
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+      val headers = resp.headers
 
       resp.as_string must_== """{"foo":"bar","baz":"boom"}"""
-      headers("content-type") must_==(Set("application/json; charset=utf-8"))
+      headers("content-type") must_==(List("application/json; charset=utf-8"))
     }
   }
 }

--- a/json4s/src/test/scala/JsonpSpec.scala
+++ b/json4s/src/test/scala/JsonpSpec.scala
@@ -1,7 +1,6 @@
 package unfiltered.request
 
 import org.specs2.mutable._
-import scala.collection.JavaConverters._
 
 object JsonpSpec extends Specification  with unfiltered.specs2.jetty.Served {
   import unfiltered.response._
@@ -56,14 +55,14 @@ object JsonpSpec extends Specification  with unfiltered.specs2.jetty.Served {
           <:< Map("Accept" -> "text/javascript"))
 
       resp.as_string must_== """onResp([42])"""
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+      val headers = resp.headers
       headers("content-type") must_==(Set("text/javascript; charset=utf-8"))
     }
     "optionally produce a json response when callback is missing" in {
       val resp = http(req(host / "jsonp" / "lift-json" / "optional")
           <:< Map("Accept" -> "application/json"))
 
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+      val headers = resp.headers
 
       resp.as_string must_== """{"answer":[42]}"""
       headers("content-type") must_==(Set("application/json; charset=utf-8"))

--- a/library/src/test/scala/BasicAuthKitSpec.scala
+++ b/library/src/test/scala/BasicAuthKitSpec.scala
@@ -31,8 +31,8 @@ trait BasicAuthKitSpec extends Specification with unfiltered.specs2.Hosted {
     }
     "not authenticate an invalid user and return a www-authenticate header" in {
       val resp = httpx(req(host / "secret").as_!("joe", "shmo"))
-      resp.code() must_== 401
-      val headers = resp.headers().toMultimap.asScala.mapValues(_.asScala.toList)
+      resp.code must_== 401
+      val headers = resp.headersAsScala
       headers must haveKey("www-authenticate")
       val authenticate = headers("www-authenticate")
       authenticate.headOption must beSome("""Basic realm="secret"""")

--- a/library/src/test/scala/BasicAuthKitSpec.scala
+++ b/library/src/test/scala/BasicAuthKitSpec.scala
@@ -32,7 +32,7 @@ trait BasicAuthKitSpec extends Specification with unfiltered.specs2.Hosted {
     "not authenticate an invalid user and return a www-authenticate header" in {
       val resp = httpx(req(host / "secret").as_!("joe", "shmo"))
       resp.code must_== 401
-      val headers = resp.headersAsScala
+      val headers = resp.headers
       headers must haveKey("www-authenticate")
       val authenticate = headers("www-authenticate")
       authenticate.headOption must beSome("""Basic realm="secret"""")

--- a/library/src/test/scala/CookiesSpec.scala
+++ b/library/src/test/scala/CookiesSpec.scala
@@ -104,7 +104,7 @@ trait CookiesSpec extends Specification with unfiltered.specs2.Hosted {
     finally { jar.clear }
   }
 
-  def httpWithCookies(jar: okhttp3.CookieJar): (okhttp3.Request) => okhttp3.Response = { req =>
+  def httpWithCookies(jar: okhttp3.CookieJar): (okhttp3.Request) => Response = { req =>
     requestWithNewClient(req, new OkHttpClient.Builder().cookieJar(jar).build())
   }
 }

--- a/library/src/test/scala/GzipSpec.scala
+++ b/library/src/test/scala/GzipSpec.scala
@@ -50,17 +50,17 @@ trait GZipSpec extends Specification with unfiltered.specs2.Hosted {
   "GZip response kit should" should {
     "gzip-encode a response when accepts header is present" in {
       val resp = http(req(host / "test") <:< Map("Accept-Encoding" -> "gzip"))
-      resp.header("Content-Encoding") must_== "gzip"
+      resp.firstHeader("Content-Encoding") must_== Some("gzip")
       gzipDecode(resp) must_== message
     }
     "gzip-encode an empty response when accepts header is present" in {
       val resp = http(req(host / "empty") <:< Map("Accept-Encoding" -> "gzip"))
-      resp.header("Content-Encoding") must_== "gzip"
+      resp.firstHeader("Content-Encoding") must_== Some("gzip")
       gzipDecode(resp) must_== ""
     }
     "serve unencoded response when accepts header is not present" in {
       val resp = http(req(host / "test"))
-      Option(resp.header("Content-Encoding")) must_== None
+      resp.firstHeader("Content-Encoding") must_== None
       resp.as_string must_== message
     }
   }

--- a/library/src/test/scala/ParamsSpec.scala
+++ b/library/src/test/scala/ParamsSpec.scala
@@ -97,7 +97,7 @@ trait ParamsSpec extends Specification with unfiltered.specs2.Hosted {
     }
     "not match on non-number" in {
       val resp = httpx(host / "int" <<? Map("number" -> "8a"))
-      resp.code() must_== 400
+      resp.code must_== 400
       resp.as_string must_== "number"
     }
     "return even number" in {
@@ -105,17 +105,17 @@ trait ParamsSpec extends Specification with unfiltered.specs2.Hosted {
     }
     "fail on non-number" in {
       val resp = httpx(host / "even" <<? Map("number"->"eight", "what"->""))
-      resp.code() must_== 400
+      resp.code must_== 400
       resp.as_string must_== "number:eight is not a number"
     }
     "fail on odd number" in {
       val resp = httpx(host / "even" <<? Map("number" -> "7"))
-      resp.code() must_== 400
+      resp.code must_== 400
       resp.as_string must_== "number:7 is odd,what:bad"
     }
     "fail on not present" in {
       val resp = httpx(host / "even")
-      resp.code() must_== 400
+      resp.code must_== 400
       resp.as_string must_== "number:missing,what:bad"
     }
     val strpoint = req(host / "str") <:< Map("User-Agent" -> "Tester")
@@ -124,7 +124,7 @@ trait ParamsSpec extends Specification with unfiltered.specs2.Hosted {
     }
     "fail 400 if param not an int" in {
       val resp = httpx(strpoint <<? Map("param" -> "one", "req"->"whew"))
-      resp.code() must_== 400
+      resp.code must_== 400
       resp.as_string must_== "param"
     }
     "return optional param if an int" in {

--- a/library/src/test/scala/PassSpec.scala
+++ b/library/src/test/scala/PassSpec.scala
@@ -37,7 +37,7 @@ trait PassSpec extends Specification with unfiltered.specs2.Hosted {
     }
     "not match with POST" in {
       val resp = httpx(req(host) << Map("what"-> "oh"))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
   }
 }

--- a/library/src/test/scala/TypeSpec.scala
+++ b/library/src/test/scala/TypeSpec.scala
@@ -1,5 +1,7 @@
 package unfiltered.request
 
+import java.nio.charset.StandardCharsets
+
 import org.specs2.mutable._
 
 object TypeSpecJetty extends Specification with unfiltered.specs2.jetty.Planned with TypeSpec
@@ -24,13 +26,13 @@ trait TypeSpec extends Specification with unfiltered.specs2.Hosted {
     "Correctly encode response in utf8 by default" in {
       val resp = http(host / "test")
 
-      resp.body().string() must_== message
+      resp.as_string must_== message
       List(resp.header("Content-Type").toLowerCase) must containPattern("text/plain; ?charset=utf-8")
     }
     "Correctly encode response in iso-8859-1 if requested" in {
       val resp = http(host / "latin")
 
-      resp.body().string() must_== message
+      resp.body.map(b => new String(b.toByteArray, StandardCharsets.ISO_8859_1)).getOrElse("") must_== message
       List(resp.header("Content-Type").toLowerCase) must containPattern("text/plain; ?charset=iso-8859-1")
     }
   }

--- a/library/src/test/scala/TypeSpec.scala
+++ b/library/src/test/scala/TypeSpec.scala
@@ -27,13 +27,13 @@ trait TypeSpec extends Specification with unfiltered.specs2.Hosted {
       val resp = http(host / "test")
 
       resp.as_string must_== message
-      List(resp.header("Content-Type").toLowerCase) must containPattern("text/plain; ?charset=utf-8")
+      resp.firstHeader("Content-Type").map(_.toLowerCase).toList must containPattern("text/plain; ?charset=utf-8")
     }
     "Correctly encode response in iso-8859-1 if requested" in {
       val resp = http(host / "latin")
 
       resp.body.map(b => new String(b.toByteArray, StandardCharsets.ISO_8859_1)).getOrElse("") must_== message
-      List(resp.header("Content-Type").toLowerCase) must containPattern("text/plain; ?charset=iso-8859-1")
+      resp.firstHeader("Content-Type").map(_.toLowerCase).toList must containPattern("text/plain; ?charset=iso-8859-1")
     }
   }
 }

--- a/mac/src/test/scala/MacSpec.scala
+++ b/mac/src/test/scala/MacSpec.scala
@@ -32,22 +32,22 @@ object MacSpec extends Specification with ThrownMessages with unfiltered.specs2.
     "respond with a challege when client omits authorization" in {
       val resp = httpx(req(host / "echo"))
       resp.code must_== 401
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
-      headers must havePair(("www-authenticate", Set("MAC")))
+      val headers = resp.headers
+      headers must havePair(("www-authenticate", List("MAC")))
      }
     "respond with a challenge when required authorization params are missing" in {
       val resp = httpx(host / "echo")
       resp.code must_== 401
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
-      headers must havePair(("www-authenticate", Set("MAC")))
+      val headers = resp.headers
+      headers must havePair(("www-authenticate", List("MAC")))
 
     }
     "respond with a challege with a malformed nonce" in {
       val resp = httpx(req(host / "echo") <:< Map(
         "Authorization" -> """MAC id="%s",nonce="%s",mac="%s" """.format("test_id", "test:test", "asdfasdf")))
       resp.code must_== 401
-      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
-      headers must havePair(("www-authenticate", Set("MAC")))
+      val headers = resp.headers
+      headers must havePair(("www-authenticate", List("MAC")))
      }
     "respond with a body when authorization is valid" in {
        val body = httpx(req(host / "echo") <:<  Map(

--- a/mac/src/test/scala/MacSpec.scala
+++ b/mac/src/test/scala/MacSpec.scala
@@ -31,22 +31,22 @@ object MacSpec extends Specification with ThrownMessages with unfiltered.specs2.
   "Mac" should {
     "respond with a challege when client omits authorization" in {
       val resp = httpx(req(host / "echo"))
-      resp.code() must_== 401
-      val headers = resp.headers().toMultimap.asScala.mapValues(_.asScala.toSet)
+      resp.code must_== 401
+      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
       headers must havePair(("www-authenticate", Set("MAC")))
      }
     "respond with a challenge when required authorization params are missing" in {
       val resp = httpx(host / "echo")
-      resp.code() must_== 401
-      val headers = resp.headers().toMultimap.asScala.mapValues(_.asScala.toSet)
+      resp.code must_== 401
+      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
       headers must havePair(("www-authenticate", Set("MAC")))
 
     }
     "respond with a challege with a malformed nonce" in {
       val resp = httpx(req(host / "echo") <:< Map(
         "Authorization" -> """MAC id="%s",nonce="%s",mac="%s" """.format("test_id", "test:test", "asdfasdf")))
-      resp.code() must_== 401
-      val headers = resp.headers().toMultimap.asScala.mapValues(_.asScala.toSet)
+      resp.code must_== 401
+      val headers = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
       headers must havePair(("www-authenticate", Set("MAC")))
      }
     "respond with a body when authorization is valid" in {

--- a/netty-server/src/test/scala/ResourcesSpec.scala
+++ b/netty-server/src/test/scala/ResourcesSpec.scala
@@ -19,7 +19,7 @@ object ResourcesSpec extends Specification with unfiltered.specs2.netty.Served {
        mustHaveType("foo.js", "application/javascript")
      }
      "respond with useful headers" in {
-       val headers = httpx(req(host / "foo.css")).headers().toMultimap.asScala
+       val headers = httpx(req(host / "foo.css")).headers.toMultimap.asScala
        headers must haveKey("date")
        headers must haveKey("expires")
        headers must haveKey("last-modified")
@@ -28,16 +28,16 @@ object ResourcesSpec extends Specification with unfiltered.specs2.netty.Served {
        headers must haveKey("cache-control")
      }
      "respond sith Forbidden (403) for requests with questionable paths" in {
-       httpx(host / ".." / "..").code() must be_==(403)
+       httpx(host / ".." / "..").code must be_==(403)
      }
      "respond with NotFound (404) for requests for non-existant files" in {
-       httpx(host / "foo.bar").code() must be_==(404)
+       httpx(host / "foo.bar").code must be_==(404)
      }
      "respond with Forbidden (403) for requests for a directory by default" in {
-       httpx(host).code() must be_==(403)
+       httpx(host).code must be_==(403)
      }
      "respond with BadRequest (400) with a non GET request" in  {
-       httpx(req(host / "foo.css").POST("")).code() must be_==(400)
+       httpx(req(host / "foo.css").POST("")).code must be_==(400)
      }
      "respond with a NotModified (304) with a If-Modified-Since matches resources lastModified time" in {
        import java.util.{Calendar, Date, GregorianCalendar}
@@ -47,7 +47,7 @@ object ResourcesSpec extends Specification with unfiltered.specs2.netty.Served {
        cal.setTime(new Date(rsrc.lastModified))
        val ifmodsince = Map(
          "If-Modified-Since" -> Dates.format(cal.getTime))
-       httpx(req(host / "foo.css") <:< ifmodsince).code() must be_==(304)
+       httpx(req(host / "foo.css") <:< ifmodsince).code must be_==(304)
      }
    }
 }

--- a/netty-server/src/test/scala/ResourcesSpec.scala
+++ b/netty-server/src/test/scala/ResourcesSpec.scala
@@ -12,14 +12,14 @@ object ResourcesSpec extends Specification with unfiltered.specs2.netty.Served {
      }
      "respond with an expected Content-Type" in {
        def mustHaveType(path: String, `type`: String) =
-         httpx(req(host / path)).header("Content-Type") must_== `type`
+         httpx(req(host / path)).firstHeader("Content-Type") must_== Some(`type`)
        mustHaveType("foo.html", "text/html")
        mustHaveType("foo.css", "text/css")
        mustHaveType("foo.txt", "text/plain")
        mustHaveType("foo.js", "application/javascript")
      }
      "respond with useful headers" in {
-       val headers = httpx(req(host / "foo.css")).headers.toMultimap.asScala
+       val headers = httpx(req(host / "foo.css")).headers
        headers must haveKey("date")
        headers must haveKey("expires")
        headers must haveKey("last-modified")

--- a/netty-uploads/build.sbt
+++ b/netty-uploads/build.sbt
@@ -4,3 +4,5 @@ unmanagedClasspath in (local("netty-uploads"), Test) ++=
   (fullClasspath in (local("specs2"), Compile)).value
 
 libraryDependencies ++= Common.integrationTestDeps(scalaVersion.value)
+
+parallelExecution in Test := false

--- a/netty-uploads/src/test/scala/AsyncUploadSpec.scala
+++ b/netty-uploads/src/test/scala/AsyncUploadSpec.scala
@@ -141,7 +141,7 @@ object AsyncUploadSpec extends Specification
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
       val resp = httpx(req(host / "notfound") <<* ("f", file, "text/plain"))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
   }
 }

--- a/netty-uploads/src/test/scala/ChunkAggregatedUploadSpec.scala
+++ b/netty-uploads/src/test/scala/ChunkAggregatedUploadSpec.scala
@@ -197,7 +197,7 @@ object ChunkAggregatedUploadSpec extends Specification
       file.exists must_==true
 
       val resp = httpx(req(host / "async" / "notfound") <<* ("f", file, "text/plain"))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
 
     // Cycle
@@ -236,7 +236,7 @@ object ChunkAggregatedUploadSpec extends Specification
       file.exists must_==true
 
       val resp = httpx(req(host / "cycle" / "notfound") <<* ("f", file, "text/plain"))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
   }
 }

--- a/netty-uploads/src/test/scala/ChunkAggregatedUploadSpec.scala
+++ b/netty-uploads/src/test/scala/ChunkAggregatedUploadSpec.scala
@@ -25,7 +25,7 @@ object ChunkAggregatedUploadSpec extends Specification
       }
       case POST(UFPath("/async/disk-upload/write") & MultiPart(req)) => MultiPartParams.Disk(req).files("f") match {
         case Seq(f, _*) =>
-          f.write(new JFile("upload-test-out.txt")) match {
+          f.write(new JFile("async-upload-test-out.txt")) match {
             case Some(outFile) =>
               if(IOU.toString(new FIS(outFile)) == new String(f.bytes)) req.respond(ResponseString(
                 "wrote disk read file f named %s with content type %s with correct contents" format(
@@ -50,7 +50,7 @@ object ChunkAggregatedUploadSpec extends Specification
         MultiPartParams.Streamed(req).files("f") match {
          case Seq(f, _*) =>
             val src = IOU.toString(getClass.getResourceAsStream("/netty-upload-big-text-test.txt"))
-            f.write(new JFile("upload-test-out.txt")) match {
+            f.write(new JFile("async-upload-test-out.txt")) match {
               case Some(outFile) =>
                 if (IOU.toString(new FIS(outFile)) == src) req.respond(ResponseString(
                   "wrote stream read file f named %s with content type %s with correct contents" format(
@@ -73,7 +73,7 @@ object ChunkAggregatedUploadSpec extends Specification
         }
         case POST(UFPath("/async/mem-upload/write") & MultiPart(req)) => MultiPartParams.Memory(req).files("f") match {
           case Seq(f, _*) =>
-            f.write(new JFile("upload-test-out.txt")) match {
+            f.write(new JFile("async-upload-test-out.txt")) match {
               case Some(outFile) => req.respond(ResponseString(
                 "wrote memory read file f is named %s with content type %s" format(
                   f.name, f.contentType)))

--- a/netty-uploads/src/test/scala/CycleUploadSpec.scala
+++ b/netty-uploads/src/test/scala/CycleUploadSpec.scala
@@ -140,7 +140,7 @@ object CycleUploadSpec extends Specification
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
       val resp = httpx(req(host / "notfound") <<* ("f", file, "text/plain"))
-      resp.code() must_== 404
+      resp.code must_== 404
     }
   }
 }

--- a/netty-uploads/src/test/scala/MixedPlanSpec.scala
+++ b/netty-uploads/src/test/scala/MixedPlanSpec.scala
@@ -137,7 +137,7 @@ object MixedPlanSpec extends Specification
     // General
 
     "respond with a 404 when passing non-parameterised content type value" in {
-      val code = httpx(req(host / "ignored").POST("f", MediaType.parse("application/x-www-form-urlencoded"))).code()
+      val code = httpx(req(host / "ignored").POST("f", MediaType.parse("application/x-www-form-urlencoded"))).code
       code must_== 404
     }
 
@@ -146,7 +146,7 @@ object MixedPlanSpec extends Specification
     "respond with 404 when posting to a non-existent url" in {
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
-      val code = httpx(req(host / "cycle" / "notexists") <<* ("f", file, "text/plain")).code()
+      val code = httpx(req(host / "cycle" / "notexists") <<* ("f", file, "text/plain")).code
       code must_== 404
     }
 
@@ -177,7 +177,7 @@ object MixedPlanSpec extends Specification
     "respond with a 404 when passing in a cycle plan with no matching intent" in {
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
-      val code = httpx(req(host / "cycle" / "passnotfound") <<* ("f", file, "text/plain")).code()
+      val code = httpx(req(host / "cycle" / "passnotfound") <<* ("f", file, "text/plain")).code
       code must_== 404
     }
 
@@ -210,7 +210,7 @@ object MixedPlanSpec extends Specification
     "respond with a 404 when passing in an async plan with no matching intent" in {
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
-      val code = httpx(req(host / "async" / "passnotfound") <<* ("f", file, "text/plain")).code()
+      val code = httpx(req(host / "async" / "passnotfound") <<* ("f", file, "text/plain")).code
       code must_== 404
     }
   }

--- a/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
+++ b/netty-uploads/src/test/scala/NoChunkAggregatorSpec.scala
@@ -94,7 +94,7 @@ object NoChunkAggregatorSpec extends Specification
     "respond with a 200 when no chunk aggregator is used in a cycle plan" in {
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
-      val code = httpx(req(host / "cycle" / "upload") <<* ("f", file, "text/plain")).code()
+      val code = httpx(req(host / "cycle" / "upload") <<* ("f", file, "text/plain")).code
       code must_== 200
     }
 
@@ -102,7 +102,7 @@ object NoChunkAggregatorSpec extends Specification
     "respond with a 200 when no chunk aggregator is used in an async plan" in {
       val file = new JFile(getClass.getResource("/netty-upload-big-text-test.txt").toURI)
       file.exists must_==true
-      val code = httpx(req(host / "async" / "upload") <<* ("f", file, "text/plain")).code()
+      val code = httpx(req(host / "async" / "upload") <<* ("f", file, "text/plain")).code
       code must_== 200
     }
 

--- a/oauth2/src/test/scala/AuthorizationSpec.scala
+++ b/oauth2/src/test/scala/AuthorizationSpec.scala
@@ -66,7 +66,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
           "client_id" -> client.id,
           "redirect_uri" -> client.redirectUri
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
       head must haveKey("location")
       new URI(head("location").head).getQuery match {
         case ErrorQueryString(err, desc) =>
@@ -80,7 +80,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
          "response_type" -> "token",
          "redirect_uri" -> client.redirectUri
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        head must haveKey("location")
        new URI(head("location").head).getFragment match {
          case ErrorQueryString(err, desc) =>
@@ -120,7 +120,7 @@ object AuthorizationSpec
          "client_id" -> client.id,
          "redirect_uri" -> client.redirectUri,
          "state" -> "test_state"
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        head must haveKey("location")
        val responseParams = Map(new URI(head("location").head).getFragment.split("&").map(_.split("=") match {
           case Array(k,v) => (k, v)
@@ -202,11 +202,11 @@ object AuthorizationSpec
          "client_id" -> client.id,
          "client_secret" -> client.secret,
          "redirect_uri" -> client.redirectUri
-      )).headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+      )).headers
       headers must haveKey("cache-control")
       headers must haveKey("pragma")
-      headers("cache-control") must be_==(Set("no-store"))
-      headers("pragma") must be_==(Set("no-cache"))
+      headers("cache-control") must be_==(List("no-store"))
+      headers("pragma") must be_==(List("no-cache"))
     }
   }
 
@@ -290,11 +290,11 @@ object AuthorizationSpec
          "client_secret" -> client.secret,
          "username" -> owner.id,
          "password" -> password
-      )).headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+      )).headers
       headers must haveKey("cache-control")
       headers must haveKey("pragma")
-      headers("cache-control") must be_==(Set("no-store"))
-      headers("pragma") must be_==(Set("no-cache"))
+      headers("cache-control") must be_==(List("no-store"))
+      headers("pragma") must be_==(List("no-cache"))
     }
   }
 
@@ -306,7 +306,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
          "client_id" -> client.id,
          "redirect_uri" -> client.redirectUri
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        head must haveKey("location")
        val uri = new URI(head("location").head)
        uri.getQuery match {
@@ -320,7 +320,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
          "response_type" -> "code",
          "redirect_uri" -> client.redirectUri
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        head must haveKey("location")
        val uri = new URI(head("location").head)
        uri.getQuery match {
@@ -344,7 +344,7 @@ object AuthorizationSpec
          "response_type" -> "code",
          "client_id" -> client.id,
          "redirect_uri" -> client.redirectUri
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        val Code = """code=(\S+)""".r
        new java.net.URI(head("location").head).getQuery match {
           case Code(code) =>
@@ -367,7 +367,7 @@ object AuthorizationSpec
          "client_id" -> client.id,
          "redirect_uri" -> client.redirectUri,
          "state" -> "test_state"
-       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers
        head must haveKey("location")
        val uri = new java.net.URI(head("location").head)
        val Code = """code=(\S+)""".r
@@ -386,7 +386,7 @@ object AuthorizationSpec
            // requesting access token
            val resp = http(request)
            val ares = resp.as_string
-           val header = resp.headers.toMultimap.asScala.mapValues(_.asScala.toSet)
+           val header = resp.headers
            // http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.2.2:
            header must haveKey("cache-control")
            header must haveKey("pragma")

--- a/oauth2/src/test/scala/AuthorizationSpec.scala
+++ b/oauth2/src/test/scala/AuthorizationSpec.scala
@@ -24,11 +24,11 @@ object AuthorizationSpec
   val owner = MockResourceOwner("doug")
   val password = "mockuserspassword"
 
-  override def http(req: okhttp3.Request): okhttp3.Response = {
+  override def http(req: okhttp3.Request): Response = {
     requestWithNewClient(req, new OkHttpClient().newBuilder().followRedirects(false).followSslRedirects(false).build())
   }
 
-  override def httpx(req: okhttp3.Request): okhttp3.Response = {
+  override def httpx(req: okhttp3.Request): Response = {
     http(req)
   }
 
@@ -66,7 +66,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
           "client_id" -> client.id,
           "redirect_uri" -> client.redirectUri
-       )).headers().toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
       head must haveKey("location")
       new URI(head("location").head).getQuery match {
         case ErrorQueryString(err, desc) =>
@@ -202,7 +202,7 @@ object AuthorizationSpec
          "client_id" -> client.id,
          "client_secret" -> client.secret,
          "redirect_uri" -> client.redirectUri
-      )).headers().toMultimap.asScala.mapValues(_.asScala.toSet)
+      )).headers.toMultimap.asScala.mapValues(_.asScala.toSet)
       headers must haveKey("cache-control")
       headers must haveKey("pragma")
       headers("cache-control") must be_==(Set("no-store"))
@@ -290,7 +290,7 @@ object AuthorizationSpec
          "client_secret" -> client.secret,
          "username" -> owner.id,
          "password" -> password
-      )).headers().toMultimap.asScala.mapValues(_.asScala.toSet)
+      )).headers.toMultimap.asScala.mapValues(_.asScala.toSet)
       headers must haveKey("cache-control")
       headers must haveKey("pragma")
       headers("cache-control") must be_==(Set("no-store"))
@@ -320,7 +320,7 @@ object AuthorizationSpec
        val head = http(authorize <<? Map(
          "response_type" -> "code",
          "redirect_uri" -> client.redirectUri
-       )).headers().toMultimap.asScala.mapValues(_.asScala.toList)
+       )).headers.toMultimap.asScala.mapValues(_.asScala.toList)
        head must haveKey("location")
        val uri = new URI(head("location").head)
        uri.getQuery match {

--- a/oauth2/src/test/scala/CustomAuthorizationSpec.scala
+++ b/oauth2/src/test/scala/CustomAuthorizationSpec.scala
@@ -48,7 +48,7 @@ object CustomAuthorizationSpec
          "redirect_uri" -> client.redirectUri
       ))
 
-      resp.code() must_== 403
+      resp.code must_== 403
       resp.as_string must_== "client_credentials not supported"
     }
   }

--- a/oauth2/src/test/scala/ProtectionSpec.scala
+++ b/oauth2/src/test/scala/ProtectionSpec.scala
@@ -19,11 +19,11 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     def id = "test_client"
   }
 
-  override def http(req: okhttp3.Request): okhttp3.Response = {
+  override def http(req: okhttp3.Request): Response = {
     requestWithNewClient(req, new OkHttpClient().newBuilder().followRedirects(false).followSslRedirects(false).build())
   }
 
-  override def httpx(req: okhttp3.Request): okhttp3.Response = {
+  override def httpx(req: okhttp3.Request): Response = {
     http(req)
   }
 
@@ -88,12 +88,12 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     "fail on a bad Bearer header" in {
       val bearer_header = Map("Authorization" -> "Bearer bad_token")
       val resp1 = httpx(req(host / "user") <:< bearer_header)
-      resp1.code() must_== 401
+      resp1.code must_== 401
       resp1.as_string must_== """error="%s" error_description="%s" """.trim.format("invalid_token", "bad token")
       val resp2 = httpx(req(host / "user") <:< bearer_header)
-      resp1.code() must_== 401
-      val head = resp2.headers().toMultimap.asScala.mapValues(_.asScala.toList)
-      head.get("WWW-Authenticate") must_!= (None)
+      resp1.code must_== 401
+      val head = resp2.headersAsScala()
+      head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")
       val expected = "Bearer error=\"%s\",error_description=\"%s\"".trim.format("invalid_token", "bad token")
       wwwAuth.head must_== expected
@@ -102,9 +102,9 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     // see http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4.1
     "fail without returning an error code and description on missing authentication information" in {
       val resp = httpx(host / "user")
-      val head = resp.headers().toMultimap.asScala.mapValues(_.asScala.toList)
-      resp.code() must_== 401
-      head.get("WWW-Authenticate") must_!= (None)
+      val head = resp.headersAsScala()
+      resp.code must_== 401
+      head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")
       wwwAuth.head must_== "Bearer"
     }
@@ -112,9 +112,9 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     "fail on a bad MAC header" in {
       val macHeader = Map("Authorization" -> """MAC id="bogus",nonce="123:y",bodyhash="bogus",mac="bogus"""")
       val resp = httpx(req(host / "user") <:< macHeader)
-      val head = resp.headers().toMultimap.asScala.mapValues(_.asScala.toList)
-      resp.code() must_== 401
-      head.get("WWW-Authenticate") must_!= (None)
+      val head = resp.headersAsScala()
+      resp.code must_== 401
+      head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")
       val expected = "MAC error=\"%s\"".trim.format("invalid token")
       wwwAuth.head must_== expected

--- a/oauth2/src/test/scala/ProtectionSpec.scala
+++ b/oauth2/src/test/scala/ProtectionSpec.scala
@@ -92,7 +92,7 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
       resp1.as_string must_== """error="%s" error_description="%s" """.trim.format("invalid_token", "bad token")
       val resp2 = httpx(req(host / "user") <:< bearer_header)
       resp1.code must_== 401
-      val head = resp2.headersAsScala()
+      val head = resp2.headers
       head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")
       val expected = "Bearer error=\"%s\",error_description=\"%s\"".trim.format("invalid_token", "bad token")
@@ -102,7 +102,7 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     // see http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4.1
     "fail without returning an error code and description on missing authentication information" in {
       val resp = httpx(host / "user")
-      val head = resp.headersAsScala()
+      val head = resp.headers
       resp.code must_== 401
       head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")
@@ -112,7 +112,7 @@ object ProtectionSpec extends Specification with org.specs2.matcher.ThrownMessag
     "fail on a bad MAC header" in {
       val macHeader = Map("Authorization" -> """MAC id="bogus",nonce="123:y",bodyhash="bogus",mac="bogus"""")
       val resp = httpx(req(host / "user") <:< macHeader)
-      val head = resp.headersAsScala()
+      val head = resp.headers
       resp.code must_== 401
       head.get("www-authenticate") must_!= (None)
       val wwwAuth = head("www-authenticate")

--- a/specs2/src/main/scala/Hosted.scala
+++ b/specs2/src/main/scala/Hosted.scala
@@ -25,10 +25,13 @@ trait Hosted {
   }
 
   def requestWithNewClient(req: Request, clientF: => OkHttpClient): Response = {
+    import collection.JavaConverters._
+
     val client = clientF
     try {
       val res = client.newCall(req).execute()
-      val transformed = Response(res.code(), res.headers(), Option(res.body()).map{ body =>
+      val headers = res.headers.toMultimap.asScala.mapValues(_.asScala.toList).toMap
+      val transformed = Response(res.code(), headers, Option(res.body()).map{ body =>
         val bytes = body.bytes()
         ByteString.of(bytes, 0, bytes.length)
       })
@@ -100,13 +103,10 @@ trait Hosted {
   }
 
 
-  case class Response(code: Int, headers: Headers, body: Option[ByteString]) {
-    import collection.JavaConverters._
-
+  case class Response(code: Int, headers: Map[String, List[String]], body: Option[ByteString]) {
     def as_string = body.map(_.utf8()).getOrElse("")
-    def header(name: String): String = headers.get(name)
-
-    def headersAsScala(): Map[String, List[String]] = headers.toMultimap.asScala.mapValues(_.asScala.toList).toMap
+    def header(name: String): Option[List[String]] = headers.get(name.toLowerCase)
+    def firstHeader(name: String): Option[String] = header(name).flatMap(_.headOption)
   }
 
   trait ByteStringToConverter[A] {

--- a/specs2/src/main/scala/Hosted.scala
+++ b/specs2/src/main/scala/Hosted.scala
@@ -1,8 +1,6 @@
 package unfiltered
 package specs2
 
-import java.nio.charset.StandardCharsets
-
 import okhttp3._
 import okio.ByteString
 import unfiltered.request.Method
@@ -15,10 +13,10 @@ trait Hosted {
 
   def http(req: Request): Response = {
     val response = httpx(req)
-    if (response.code() == 200) {
+    if (response.code == 200) {
       response
     } else {
-      throw StatusCode(response.code())
+      throw StatusCode(response.code)
     }
   }
 
@@ -29,7 +27,13 @@ trait Hosted {
   def requestWithNewClient(req: Request, clientF: => OkHttpClient): Response = {
     val client = clientF
     try {
-      client.newCall(req).execute()
+      val res = client.newCall(req).execute()
+      val transformed = Response(res.code(), res.headers(), Option(res.body()).map{ body =>
+        val bytes = body.bytes()
+        ByteString.of(bytes, 0, bytes.length)
+      })
+      res.close()
+      transformed
     } finally {
       client.dispatcher().executorService().shutdown()
     }
@@ -90,9 +94,19 @@ trait Hosted {
     def <<*(name: String, file: java.io.File, mt: String) = {
       val mp = new MultipartBody.Builder().
         setType(MultipartBody.FORM).
-        addFormDataPart(name, file.getName, RequestBody.create(MediaType.parse("text/plain"), file)).build()
+        addFormDataPart(name, file.getName, RequestBody.create(MediaType.parse(mt), file)).build()
       POST(mp)
     }
+  }
+
+
+  case class Response(code: Int, headers: Headers, body: Option[ByteString]) {
+    import collection.JavaConverters._
+
+    def as_string = body.map(_.utf8()).getOrElse("")
+    def header(name: String): String = headers.get(name)
+
+    def headersAsScala(): Map[String, List[String]] = headers.toMultimap.asScala.mapValues(_.asScala.toList).toMap
   }
 
   trait ByteStringToConverter[A] {
@@ -114,23 +128,4 @@ trait Hosted {
   }
 
   implicit def urlToGetRequest(url: HttpUrl): Request = req(url)
-
-  implicit class ResponseWrapper(res: Response) {
-    def as_string = as[String]
-    def as[T](implicit handler: ResponseHandler[T]) = handler.apply(res)
-  }
-
-  trait ResponseHandler[T] {
-    final def apply(res: Response): T = try { convert(res) } finally { res.close() }
-    def convert(res: Response): T
-  }
-
-  object ResponseHandler {
-    def lift[T](f: Response => T) = new ResponseHandler[T] {
-      def convert(res: Response) = f(res)
-    }
-
-    implicit val String: ResponseHandler[String] = lift((res) => res.body().string())
-    implicit val Response: ResponseHandler[Response] = lift(identity)
-  }
 }

--- a/specs2/src/main/scala/SecureClient.scala
+++ b/specs2/src/main/scala/SecureClient.scala
@@ -31,10 +31,10 @@ trait SecureClient extends Hosted {
 
   def https(req: Request): Response = {
     val response = httpsx(req)
-    if (response.code() == 200) {
+    if (response.code == 200) {
       response
     } else {
-      throw StatusCode(response.code())
+      throw StatusCode(response.code)
     }
   }
 


### PR DESCRIPTION
I've now extracted a Response type so we handle the response closing a bit better.

Another way to do this is to handle all the response within a function, that closes the response after it has been consumed.

I tried doing the least invasive way first. If this is not good enough, I can take a stab on doing the other way.

Another fix here is for handling the erratic nature of the netty-upload test. It might have something to do with the nature of file systems, which is a bit hard to fix, so I made these tests sequential.

We should do some more test-runs before we merge.