### PR TITLE
Update jetty to 9.3.14.v20161028, servlet-api to 3.1.

### DIFF
--- a/library/src/test/scala/HeadersSpec.scala
+++ b/library/src/test/scala/HeadersSpec.scala
@@ -97,7 +97,9 @@ trait HeadersSpec extends Specification with unfiltered.specs2.Hosted {
       get("te", ("TE","trailers, deflate;q=0.5")) must_== "pass"
     }
     "parse Upgrade" in { // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.42
-      get("u", ("Upgrade","HTTP/2.0, SHTTP/1.3, IRC/6.9, RTA/x11")) must_== "pass"
+      // Connection: upgrade MUST be sent with Upgrade header
+      // https://tools.ietf.org/html/rfc7230#page-59
+      get("u", ("Connection", "upgrade"), ("Upgrade","HTTP/2.0, SHTTP/1.3, IRC/6.9, RTA/x11")) must_== "pass"
     }
     "parse User-Agent" in { // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
       get("ua", ("User-Agent","CERN-LineMode/2.15 libwww/2.17b3")) must_== "pass"

--- a/project/common.scala
+++ b/project/common.scala
@@ -3,8 +3,8 @@ import sbt._
 object Common {
   import Keys._
 
-  val servletApiDep = "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"
-  val jettyVersion = "9.2.5.v20141112"
+  val servletApiDep = "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
+  val jettyVersion = "9.3.14.v20161028"
 
   def specs2Dep(sv: String) =
     "org.specs2" %% "specs2-core" % "3.8.6"


### PR DESCRIPTION
We were using a 2 year old version of Jetty.

Also fixes the Upgrade header test (must send Connection: upgrade).

Note: Jetty 9.3 requires JDK 8, so I think we're stuck on 9.2 for the foreseeable future.