### PR TITLE
Update jetty to 9.2.19.v20160908, servlet-api to 3.1.

### DIFF
--- a/project/common.scala
+++ b/project/common.scala
@@ -3,8 +3,8 @@ import sbt._
 object Common {
   import Keys._
 
-  val servletApiDep = "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"
-  val jettyVersion = "9.2.5.v20141112"
+  val servletApiDep = "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
+  val jettyVersion = "9.2.19.v20160908"
 
   def specs2Dep(sv: String) =
     "org.specs2" %% "specs2-core" % "3.8.6"


### PR DESCRIPTION
Update jetty to the latest version of 9.2.x.

It turns out that jetty 9.x implements servlet-api 3.1, not 3.0.1. This must have been missed when moving from jetty 8 to 9.