### PR TITLE
Build 0.8.4 for Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-before_script:
- - "echo $JAVA_OPTS"
- - "export JAVA_OPTS='-Xmx512m -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M'"
 language: scala
+sudo: false
 scala:
-  - 2.10.4
+  - 2.12.0
 jdk:
-  - openjdk6
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ scala:
   - 2.12.0
 jdk:
   - oraclejdk8
+script:
+  - sbt ++2.12.0 publish

--- a/directives/build.sbt
+++ b/directives/build.sbt
@@ -2,7 +2,3 @@ description := "monadic api for unfiltered"
 
 unmanagedClasspath in (local("directives"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
-
-
-libraryDependencies +=
-  "net.databinder.dispatch" %% "dispatch-core" % "0.11.0" % "test"

--- a/json4s/build.sbt
+++ b/json4s/build.sbt
@@ -7,5 +7,5 @@ unmanagedClasspath in (local("json4s"), Test) <++=
    }
 
 libraryDependencies <++= scalaVersion( sv =>
-  Seq("org.json4s" %% "json4s-native" % "3.2.9") ++ Common.integrationTestDeps(sv)
+  Seq("org.json4s" %% "json4s-native" % "3.4.2") ++ Common.integrationTestDeps(sv)
 )

--- a/library/build.sbt
+++ b/library/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies <++= scalaVersion(v => Seq(
 libraryDependencies <<= (libraryDependencies, scalaVersion){
   (dependencies, scalaVersion) =>
   if(!(scalaVersion.startsWith("2.9") || scalaVersion.startsWith("2.10")))
-    ("org.scala-lang.modules" %% "scala-xml" % "1.0.1") +: dependencies
+    ("org.scala-lang.modules" %% "scala-xml" % "1.0.5") +: dependencies
   else
     dependencies
 }

--- a/netty-websockets/build.sbt
+++ b/netty-websockets/build.sbt
@@ -4,5 +4,3 @@ unmanagedClasspath in (local("netty-websockets"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(Common.integrationTestDeps _)
-
-libraryDependencies += "me.lessis" %% "tubesocks" % "0.1.0" % "test"// exclude("io.netty", "netty")

--- a/oauth/build.sbt
+++ b/oauth/build.sbt
@@ -4,6 +4,5 @@ unmanagedClasspath in (local("oauth"), Test) <++=
   (fullClasspath in (local("specs2"), Compile))
 
 libraryDependencies <++= scalaVersion(v =>
-  Seq(Common.dispatchOAuthDep % "test") ++
   Common.integrationTestDeps(v)
 )

--- a/project/build.scala
+++ b/project/build.scala
@@ -45,7 +45,7 @@ object Unfiltered extends Build {
             library, filters, filtersAsync , uploads, filterUploads,
             nettyUploads, util, jetty,
             jettyAjpProject, netty, nettyServer, json4s,
-            specs2Helpers, scalaTestHelpers, websockets, oauth,  mac,
+            websockets, oauth,  mac,
             oauth2, agents, directives)
 
   lazy val library: Project =

--- a/project/common.scala
+++ b/project/common.scala
@@ -9,7 +9,7 @@ object Common {
   def specs2Dep(sv: String) =
     sv.split("[.-]").toList match {
       case "2" :: "9" :: _ => "org.specs2" %% "specs2" % "1.12.4.1"
-      case _ => "org.specs2" %% "specs2" % "2.3.11"
+      case _ => "org.specs2" %% "specs2" % "2.4.17"
     }
 
 

--- a/project/common.scala
+++ b/project/common.scala
@@ -21,7 +21,7 @@ object Common {
   def dispatchOAuthDep =
     "net.databinder" %% "dispatch-oauth" % dispatchVersion
 
-  def integrationTestDeps(sv: String) = (specs2Dep(sv) :: dispatchDeps) map { _ % "test" }
+  def integrationTestDeps(sv: String) = (specs2Dep(sv) :: Nil) map { _ % "test" }
 
   val settings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "net.databinder",

--- a/project/common.scala
+++ b/project/common.scala
@@ -26,9 +26,9 @@ object Common {
   val settings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "net.databinder",
 
-    version := "0.8.4",
+    version := "0.8.4-RC1",
 
-    crossScalaVersions := Seq("2.11.2", "2.10.4"),
+    crossScalaVersions := Seq("2.12.0" ,"2.11.2", "2.10.4"),
 
     scalaVersion := crossScalaVersions.value.head,
 

--- a/scalatest/build.sbt
+++ b/scalatest/build.sbt
@@ -1,3 +1,3 @@
 description := "Facilitates testing Unfiltered servers with ScalaTest"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1"

--- a/scalatest/build.sbt
+++ b/scalatest/build.sbt
@@ -1,3 +1,3 @@
 description := "Facilitates testing Unfiltered servers with ScalaTest"
 
-libraryDependencies ++= Common.dispatchDeps :+ "org.scalatest" %% "scalatest" % "2.2.1"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1"

--- a/specs2/build.sbt
+++ b/specs2/build.sbt
@@ -1,5 +1,5 @@
 description := "Facilitates testing Unfiltered servers with Specs2"
 
 libraryDependencies <++= scalaVersion { v =>
-  Common.specs2Dep(v) :: Common.dispatchDeps
+  Common.specs2Dep(v) :: Nil
 }


### PR DESCRIPTION
I see there is an effort to make a 0.9.0 release for Scala 2.12.

What about publishing a Scala 2.12 build of 0.8.4?  I'm suggesting here it be released as 0.8.4-RC1, since it's un-tested.  Because of circular dependencies with Dispatch, unfiltered-specs2 and unfiltered-scalatest are disabled.

To get the tests for Dispatch 0.11.2 to run against Scala 2.12, it requires a 0.8.4 build of unfiltered-netty-server for Scala 2.12.

Maybe there are other users of Unfiltered, besides Dispatch, who would appreciate an 0.8.4 build of 2.12, as well.

For what it's worth, if Dispatch is able to produce a source compatible build for Scala 2.12, then in return Unfiltered 0.8.4 will be closer to running its tests in Scala 2.12.

As pointed out in #319, there are test dependencies in Unfiltered against:

- dispatch-core 0.11.0 and
- dispatch-mime, dispatch-http and dispatch-oauth 0.8.10 ("dispatch-classic").

For now, those are ripped out in this branch.  This branch doesn't need to be merged.  It's a short-term hack.  Once an Unfiltered build for 2.12 is pushed up, Dispatch could push a 2.12.0 build of 0.11.2.

```
$ sbt clean ++2.12.0 compile doc packageDoc packageSrc packageBin publish
[info] Loading global plugins from ~/.sbt/0.13/plugins
[info] Loading project definition from ./project
[warn] Multiple resolvers having different access mechanism configured with same name 'sbt-plugin-releases'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
[info] Updating {file:./project/}unfiltered-build...
[info] Done updating.
[info] Compiling 2 Scala sources to ./project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to Unfiltered (in build file:./)
[success] Total time: 1 s, completed Nov 30, 2016 2:59:39 PM
...
[success] Total time: 64 s, completed Nov 30, 2016 3:00:45 PM
...
[info] Main Scala API documentation successful.
[success] Total time: 27 s, completed Nov 30, 2016 3:01:13 PM
...
[info] Done packaging.
[success] Total time: 3 s, completed Nov 30, 2016 3:01:16 PM
...
[info] Done packaging.
[success] Total time: 0 s, completed Nov 30, 2016 3:01:16 PM
[info] Packaging ./target/scala-2.12/unfiltered_2.12-0.8.4-RC1.jar ...
[info] Done packaging.
[success] Total time: 1 s, completed Nov 30, 2016 3:01:17 PM
[info] Wrote ./util/target/scala-2.12/unfiltered-util_2.12-0.8.4-RC1.pom
[info] Wrote ./target/scala-2.12/unfiltered_2.12-0.8.4-RC1.pom
[info] :: delivering :: net.databinder#unfiltered-util_2.12;0.8.4-RC1 :: 0.8.4-RC1 :: release :: Wed Nov 30 15:01:18 EST 2016
...
[error] Unable to find credentials for [Sonatype Nexus Repository Manager @ oss.sonatype.org].
...
[error] (unfiltered-all/*:publish) java.io.IOException: Access to URL https://oss.sonatype.org/service/local/staging/deploy/maven2/net/databinder/unfiltered_2.12/0.8.4-RC1/unfiltered_2.12-0.8.4-RC1.pom was refused by the server: Unauthorized
...
[error] Total time: 5 s, completed Nov 30, 2016 3:01:22 PM
```