### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/library/src/test/scala/CookiesSpec.scala
+++ b/library/src/test/scala/CookiesSpec.scala
@@ -17,7 +17,7 @@ object CookiesSpecNetty
 
 trait CookiesSpec extends Specification with unfiltered.specs2.Hosted {
 
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   import unfiltered.response._
   import unfiltered.request.{Path => UFPath}
@@ -71,11 +71,11 @@ trait CookiesSpec extends Specification with unfiltered.specs2.Hosted {
       withCookieJar { jar =>
         val h = httpWithCookies(jar)
         h(req(host / "save") << Map("foo" -> "bar")).as_string must_== "foo bar!"
-        val someCookies = jar.loadForRequest(host / "save")
+        val someCookies = jar.loadForRequest(host / "save").asScala
         someCookies.size must_== 1
         someCookies.find(_.name == "foo") must beSome
         h(host / "clear").as_string must_== "foo who?"
-        val noCookies = jar.loadForRequest(host / "clear")
+        val noCookies = jar.loadForRequest(host / "clear").asScala
         noCookies.size must_== 0
         noCookies.find(_.name == "foo") must beNone
       }
@@ -84,12 +84,12 @@ trait CookiesSpec extends Specification with unfiltered.specs2.Hosted {
       withCookieJar { jar =>
         val h = httpWithCookies(jar)
         h(req(host/ "save_multi") << Map("foo" -> "bar", "baz" -> "boom")).as_string must_== "foo bar baz boom!"
-        val someCookies = jar.loadForRequest(host/ "save_multi")
+        val someCookies = jar.loadForRequest(host/ "save_multi").asScala
         someCookies.size must_== 2
         someCookies.find(_.name == "foo") must beSome
         someCookies.find(_.name == "baz") must beSome
         h(host / "clear_multi").as_string must_== "foo who?"
-        val noCookies = jar.loadForRequest(host / "clear")
+        val noCookies = jar.loadForRequest(host / "clear").asScala
         noCookies.size must_== 0
         noCookies.find(_.name == "foo") must beNone
         noCookies.find(_.name == "baz") must beNone

--- a/netty-server/src/main/scala/resources/resolvers.scala
+++ b/netty-server/src/main/scala/resources/resolvers.scala
@@ -53,9 +53,8 @@ case class JarResource(url: URL) extends Resource {
   val directory = path.endsWith("/")
   val hidden = false
   lazy val entry = jarfile.flatMap { jar =>
-    import scala.collection.JavaConversions.enumerationAsScalaIterator
-    enumerationAsScalaIterator(jar.entries)
-      .find(_.getName.replace("\\","/") == path)
+    import scala.collection.JavaConverters._
+    jar.entries.asScala.find(_.getName.replace("\\","/") == path)
   }
   lazy val exists = entry.isDefined
   lazy val lastModified = entry match  {

--- a/util/src/main/scala/mime.scala
+++ b/util/src/main/scala/mime.scala
@@ -21,11 +21,11 @@ class MIMEType(val major: String,
 object MIMEType {
   def unapply(mt: String): Option[MIMEType] = {
     import javax.activation.MimeType
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
     util.control.Exception.allCatch.opt {
       val mimeType = new MimeType(mt)
       val names = mimeType.getParameters.getNames
-      val params = names.foldLeft(Map.empty[String, String]) {
+      val params = names.asScala.foldLeft(Map.empty[String, String]) {
         case (acc, p: String) =>
           acc + (p -> mimeType.getParameter(p))
       }


### PR DESCRIPTION
JavaConversions is deprecated since Scala 2.12
https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/JavaConversions.scala#L59