### PR TITLE
remove jetty-ajp from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,10 +24,6 @@ Provides asynchronous support for the filter module
 
 Provides an embedded web server abstraction for serving filters.
 
-### jetty-ajp
-
-An embedded server that adheres to the ajp protocol.
-
 ### netty
 
 Binds the core library to a Netty channel handler and provides an embedded server.


### PR DESCRIPTION
removed in https://github.com/unfiltered/unfiltered/commit/1ceec91bd00ef609ec25cf31bb228bb939e25e12