### PR TITLE
Make it possible to create Async intents from sync intents.

### DIFF
--- a/library/src/main/scala/intents.scala
+++ b/library/src/main/scala/intents.scala
@@ -1,7 +1,7 @@
 package unfiltered
 
 import unfiltered.request.HttpRequest
-import unfiltered.response.{ResponseFunction,Pass}
+import unfiltered.response.{Pass, ResponseFunction}
 
 object Cycle {
   /** A roundtrip intent is a set of instructions for producing
@@ -22,8 +22,12 @@ object Async {
     PartialFunction[HttpRequest[A] with Responder[B], Any]
   object Intent {
     def apply[A,B](intent: Intent[A,B]) = intent
+
+    def fromSync[A,B](intent: Cycle.Intent[A, B]): Intent[A, B] = {
+      case req if intent.isDefinedAt(req) => req.respond(intent(req))
+    }
   }
   trait Responder[+R] {
-    def respond(rf: unfiltered.response.ResponseFunction[R]): Unit
+    def respond(rf: ResponseFunction[R]): Unit
   }
 }

--- a/library/src/test/scala/BasicAuthKitSpec.scala
+++ b/library/src/test/scala/BasicAuthKitSpec.scala
@@ -5,22 +5,37 @@ import org.specs2.mutable._
 object BasicAuthKitSpecJetty
 extends Specification
 with unfiltered.specs2.jetty.Planned
-with BasicAuthKitSpec
+with BasicAuthKitSpecSync
 
 object BasicAuthKitSpecNetty
 extends Specification
 with unfiltered.specs2.netty.Planned
-with BasicAuthKitSpec
+with BasicAuthKitSpecSync
 
+object BasicAuthKitSpecNettyAsync
+extends Specification
+with unfiltered.specs2.netty.PlannedAsync
+with BasicAuthKitSpecAsync
 
-trait BasicAuthKitSpec extends Specification with unfiltered.specs2.Hosted {
+trait BasicAuthKitSpecSync extends BasicAuthKitSpec {
   import unfiltered.response._
-
-  def valid(u: String, p: String) = (u,p) match { case ("test", "secret") => true case _ => false }
 
   def intent[A,B]: unfiltered.Cycle.Intent[A,B] = unfiltered.kit.Auth.basic(valid)({
     case _ => ResponseString("we're in")
   })
+}
+
+trait BasicAuthKitSpecAsync extends BasicAuthKitSpec {
+  import unfiltered.response._
+
+  def intent[A,B]: unfiltered.Async.Intent[A,B] = unfiltered.Async.Intent.fromSync(unfiltered.kit.Auth.basic(valid)({
+    case _ => ResponseString("we're in")
+  }))
+}
+
+trait BasicAuthKitSpec extends Specification with unfiltered.specs2.Hosted {
+
+  def valid(u: String, p: String) = (u,p) match { case ("test", "secret") => true case _ => false }
 
   "Basic Auth kit" should {
     "authenticate a valid user" in {

--- a/specs2/src/main/scala/netty/Served.scala
+++ b/specs2/src/main/scala/netty/Served.scala
@@ -1,15 +1,20 @@
 package unfiltered.specs2.netty
 
 import unfiltered.netty.{Server, ServerErrorResponse}
-import unfiltered.netty.cycle.{DeferralExecutor, DeferredIntent, Plan}
+import unfiltered.netty.cycle
+import unfiltered.netty.async
 import org.specs2.mutable._
 import io.netty.channel.ChannelHandler.Sharable
 import io.netty.util.ResourceLeakDetector
-import org.specs2.specification.BeforeAfterAll
 
 trait Planned extends Served {
   def setup = _.plan(planify(intent))
   def intent[A,B]: unfiltered.Cycle.Intent[A,B]
+}
+
+trait PlannedAsync extends Served {
+  def setup = _.plan(planifyAsync(intent))
+  def intent[A,B]: unfiltered.Async.Intent[A,B]
 }
 
 trait Served extends Started {
@@ -43,14 +48,26 @@ trait Started extends unfiltered.specs2.Hosted with SpecificationLike {
 
   /** planify using a local executor. Global executor is problematic
    *  for tests since it is shutdown by each server instance.*/
-  def planify(intentIn: Plan.Intent) =
+  def planify(intentIn: cycle.Plan.Intent) =
     new StartedPlan(intentIn)
 
+  /** planify using a local executor. Global executor is problematic
+   *  for tests since it is shutdown by each server instance.*/
+  def planifyAsync(intentIn: async.Plan.Intent) =
+    new AsyncStartedPlan(intentIn)
+
   @Sharable
-  class StartedPlan(intentIn: Plan.Intent) extends Plan
-   with DeferralExecutor
-   with DeferredIntent
+  class StartedPlan(intentIn: cycle.Plan.Intent) extends cycle.Plan
+   with cycle.DeferralExecutor
+   with cycle.DeferredIntent
    with ServerErrorResponse {
+    def underlying = executor
+    val intent = intentIn
+  }
+
+  @Sharable
+  class AsyncStartedPlan(intentIn: async.Plan.Intent) extends async.Plan
+    with ServerErrorResponse {
     def underlying = executor
     val intent = intentIn
   }


### PR DESCRIPTION
Added possiblitiy to create both sync and async tests for Netty ( specs2 ).
We should probably do the same for scalatest.

There are some interesting ideas here. 
However, this might open a can of worms that we cannot control, like someone doing file upload using the sync interface and failing when lifted to async. 

Writing this code yourself is quite easy, as this is a simple partial function.

Lets discuss this before merging, if we want to merge at all.