### PR TITLE
Update netty, jodatime, json4s, and scalacheck.

### DIFF
--- a/netty-server/src/main/scala/Server.scala
+++ b/netty-server/src/main/scala/Server.scala
@@ -112,8 +112,8 @@ case class Server(
       /* http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#11.0 */
       .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024))
       .childOption(ChannelOption.SO_KEEPALIVE, JBoolean.TRUE)
-      .option(ChannelOption.SO_RCVBUF, JInteger.valueOf(128 * 1024))
-      .option(ChannelOption.SO_SNDBUF, JInteger.valueOf(128 * 1024))
+      .childOption(ChannelOption.SO_RCVBUF, JInteger.valueOf(128 * 1024))
+      .childOption(ChannelOption.SO_SNDBUF, JInteger.valueOf(128 * 1024))
       .option(ChannelOption.SO_REUSEADDR, JBoolean.TRUE)
       .option(ChannelOption.SO_BACKLOG, JInteger.valueOf(16384))
 

--- a/netty-server/src/main/scala/http.scala
+++ b/netty-server/src/main/scala/http.scala
@@ -140,8 +140,8 @@ trait NettyBase extends RunnableServer {
       .childHandler(initializer)
       .childOption(ChannelOption.TCP_NODELAY, JBoolean.TRUE)
       .childOption(ChannelOption.SO_KEEPALIVE, JBoolean.TRUE)
-      .option(ChannelOption.SO_RCVBUF, JInteger.valueOf(128 * 1024))
-      .option(ChannelOption.SO_SNDBUF, JInteger.valueOf(128 * 1024))
+      .childOption(ChannelOption.SO_RCVBUF, JInteger.valueOf(128 * 1024))
+      .childOption(ChannelOption.SO_SNDBUF, JInteger.valueOf(128 * 1024))
       .option(ChannelOption.SO_REUSEADDR, JBoolean.TRUE)
       .option(ChannelOption.SO_BACKLOG, JInteger.valueOf(16384)))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,16 +11,16 @@ object Dependencies {
   def integrationTestDeps(sv: String) = (specs2Dep(sv) :: okHttp) map { _ % "test" }
 
   val commonsCodecVersion = "1.10"
-  val scalacheckVersion = "1.13.4"
-  val jodaTimeVersion = "2.9.7"
+  val scalacheckVersion = "1.13.5"
+  val jodaTimeVersion = "2.9.9"
   val jodaConvertVersion = "1.8.1"
   val scalaXmlVersion = "1.0.6"
   val commonsIoVersion = "2.5"
   val commonsFileUploadVersion = "1.3.2"
   val jettyVersion = "9.2.21.v20170120"
-  val nettyVersion = "4.1.8.Final"
+  val nettyVersion = "4.1.9.Final"
   val scalatestVersion = "3.0.1"
-  val json4sVersion = "3.5.0"
+  val json4sVersion = "3.5.1"
   val asyncHttpClientVersion = "1.8.17"
   val scribeJavaVersion = "3.3.0"
 }


### PR DESCRIPTION
Also include https://github.com/unfiltered/unfiltered/pull/376 for 0.9.x branch.