### PR TITLE
Upgrade to jetty 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 sudo: false
 scala:
-  - 2.10.7
   - 2.11.12
   - 2.12.4
   - 2.13.0-M2

--- a/json4s/src/test/scala/JsonSpec.scala
+++ b/json4s/src/test/scala/JsonSpec.scala
@@ -23,7 +23,7 @@ object JsonSpec extends Specification  with unfiltered.specs2.jetty.Served {
       val headers = resp.headers
 
       resp.as_string must_== """{"foo":"bar","baz":"boom"}"""
-      headers("content-type") must_==(List("application/json; charset=utf-8"))
+      headers("content-type") must_==(List("application/json;charset=utf-8"))
     }
   }
 }

--- a/json4s/src/test/scala/JsonpSpec.scala
+++ b/json4s/src/test/scala/JsonpSpec.scala
@@ -64,7 +64,7 @@ object JsonpSpec extends Specification  with unfiltered.specs2.jetty.Served {
       val headers = resp.headers
 
       resp.as_string must_== """{"answer":[42]}"""
-      headers("content-type") must_==(List("application/json; charset=utf-8"))
+      headers("content-type") must_==(List("application/json;charset=utf-8"))
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,13 +4,7 @@ object Dependencies {
   val servletApiDep = "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
 
   def specs2Dep(sv: String) = {
-    val v = CrossVersion.partialVersion(sv) match {
-      case Some((2, 10)) =>
-        "3.9.4"
-      case _ =>
-        "4.0.1"
-    }
-    "org.specs2" %% "specs2-core" % v
+    "org.specs2" %% "specs2-core" % "4.0.1"
   }
 
   def okHttp = "com.squareup.okhttp3" % "okhttp" % "3.5.0" :: Nil
@@ -22,7 +16,7 @@ object Dependencies {
   val scalaXmlVersion = "1.0.6"
   val commonsIoVersion = "2.6"
   val commonsFileUploadVersion = "1.3.3"
-  val jettyVersion = "9.2.23.v20171218"
+  val jettyVersion = "9.4.8.v20171121"
   val nettyVersion = "4.1.13.Final"
   val scalatestVersion = "3.0.4"
   val json4sVersion = "3.5.3"

--- a/project/common.scala
+++ b/project/common.scala
@@ -14,7 +14,7 @@ object Common {
   val settings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "ws.unfiltered",
 
-    crossScalaVersions := Seq("2.13.0-M2", Scala212, "2.11.12", "2.10.7"),
+    crossScalaVersions := Seq("2.13.0-M2", Scala212, "2.11.12"),
 
     scalaVersion := Scala212,
 


### PR DESCRIPTION
Also drops Scala 2.10 support

Will require Java 8 from now.