### PR TITLE
Revert netty to 4.1.54

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val commonsIoVersion = "2.8.0"
   val commonsFileUploadVersion = "1.4"
   val jettyVersion = "11.0.0"
-  val nettyVersion = "4.1.55.Final"
+  val nettyVersion = "4.1.54.Final"
   val scalatestVersion = "3.2.3"
   val scalatestScalacheckVersion = "3.2.3.0"
   val json4sVersion = "3.6.10"


### PR DESCRIPTION
Per https://github.com/netty/netty/pull/10855

It's currently possible for anyone to DoS your netty service by sending a multipart request.

It looks like this in the real world:

```
"pool-5-thread-5" #212 prio=5 os_prio=0 cpu=35469930.07ms elapsed=61604.78s allocated=13031M defined_classes=365 tid=0x00007fc4d0000d50 nid=0x7372 runna
ble  [0x00007fc5a08f2000]
   java.lang.Thread.State: RUNNABLE
        at io.netty.buffer.AbstractByteBuf.indexOf(AbstractByteBuf.java:1254)
        at io.netty.buffer.AbstractByteBuf.bytesBefore(AbstractByteBuf.java:1306)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.findDelimiter(HttpPostMultipartRequestDecoder.java:1129)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.loadDataMultipart(HttpPostMultipartRequestDecoder.java:1171)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.decodeMultipart(HttpPostMultipartRequestDecoder.java:552)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.findMultipartDisposition(HttpPostMultipartRequestDecoder.java:795)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.decodeMultipart(HttpPostMultipartRequestDecoder.java:504)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.findMultipartDelimiter(HttpPostMultipartRequestDecoder.java:656)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.decodeMultipart(HttpPostMultipartRequestDecoder.java:491)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.parseBodyMultipart(HttpPostMultipartRequestDecoder.java:456)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.parseBody(HttpPostMultipartRequestDecoder.java:425)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.offer(HttpPostMultipartRequestDecoder.java:353)
        at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.<init>(HttpPostMultipartRequestDecoder.java:189)
        at io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.<init>(HttpPostRequestDecoder.java:93)
        at io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.<init>(HttpPostRequestDecoder.java:69)
        at unfiltered.netty.request.PostDecoder.liftedTree1$1(decoder.scala:29)
        at unfiltered.netty.request.PostDecoder.decoder$lzycompute(decoder.scala:29)
        - locked <0x00007fd053041028> (a unfiltered.netty.request.PostDecoder)
        at unfiltered.netty.request.PostDecoder.unfiltered$netty$request$PostDecoder$$decoder(decoder.scala:28)
```

Revert netty so our users don't hit this issue.