### PR TITLE
Decode any methods that has a multipart body

### DIFF
--- a/netty-uploads/src/main/scala/request/decoder.scala
+++ b/netty-uploads/src/main/scala/request/decoder.scala
@@ -114,7 +114,7 @@ trait AbstractMultiPartDecoder extends CleanUp {
         val binding = new RequestBinding(ReceivedMessage(request, ctx, request))
         binding match {
           // Should match the initial multipart request
-          case POST(MultiPart(_)) =>
+          case MultiPart(_) =>
             // Determine whether the request is destined for this plan's intent and if not, pass
             handleOrPass(ctx, request, binding) {
               // The request is destined for this intent, so start to handle it


### PR DESCRIPTION
This makes `AbstractMultiPartDecoder` allow any methods, not only `POST`.


The current implementation accepts only if the method is `POST`. For example, if you send a `PUT` request with a multipart body, it does not work. This PR removes the constraint. The underlying Netty's `HttpPostMultipartRequestDecoder
` should work fine with other methods.

Thanks,
Akira