### PR TITLE
Path traversal vulnerability

### DIFF
--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -158,7 +158,6 @@ case class Resources(
    */
   private def safe(uri: String): Option[Resource] =
     decode(uri) flatMap { decoded =>
-      println(uri)
       decoded.replace('/', File.separatorChar) match {
         case p
           if (p.contains(File.separator + ".") ||

--- a/netty-server/src/main/scala/resources.scala
+++ b/netty-server/src/main/scala/resources.scala
@@ -1,22 +1,27 @@
 package unfiltered.netty
 
 import unfiltered.netty.async.Plan
-import unfiltered.netty.resources.{FileSystemResource, Resolve, Resource}
-import unfiltered.request.{&, GET, HEAD, HttpRequest, IfModifiedSince, Path}
-import unfiltered.response.{BadRequest, CacheControl, Connection, ContentLength, ContentType, Date, Expires, Forbidden, LastModified, NotFound, NotModified, Ok, Pass, PlainTextContent, ResponseFunction}
-import io.netty.channel.{ChannelFuture, ChannelFutureListener, DefaultFileRegion}
-import io.netty.channel.ChannelHandler.Sharable
-import io.netty.handler.codec.http.{HttpHeaders, HttpResponse, HttpUtil, LastHttpContent}
-import io.netty.handler.stream.{ChunkedFile, ChunkedStream}
-import io.netty.util.CharsetUtil
+import unfiltered.netty.resources.{ FileSystemResource, Resolve, Resource }
+import unfiltered.request.{ GET, HEAD, HttpRequest, IfModifiedSince, Path, & }
+import unfiltered.response.{
+  BadRequest, CacheControl, Connection, ContentLength, ContentType, Date,
+  Expires, Forbidden, LastModified, NotFound, NotModified, Ok,
+  Pass, PlainTextContent, ResponseFunction }
 
-import java.io.{File, FileNotFoundException, RandomAccessFile}
-import java.net.{URL, URLDecoder}
+import io.netty.channel.{ ChannelFuture, ChannelFutureListener, DefaultFileRegion }
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.handler.codec.http.{
+  LastHttpContent, HttpHeaders, HttpResponse, HttpUtil }
+import io.netty.handler.stream.{ ChunkedFile, ChunkedStream }
+import io.netty.util.CharsetUtil
+import java.io.{ File, FileNotFoundException, RandomAccessFile }
+import java.net.{ URL, URLDecoder }
 import java.text.SimpleDateFormat
-import java.util.{Calendar, GregorianCalendar}
+import java.util.{ Calendar, GregorianCalendar }
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.activation.MimetypesFileTypeMap
-import scala.util.{Failure, Success, Try}
+
+import scala.util.Try
 import scala.util.control.Exception.allCatch
 
 object Mimes {

--- a/netty-server/src/test/scala/ResourcesSpec.scala
+++ b/netty-server/src/test/scala/ResourcesSpec.scala
@@ -1,5 +1,6 @@
 package unfiltered.netty
 
+import okhttp3.HttpUrl
 import org.specs2.mutable.Specification
 
 /** Tests a netty server configured to handle static resources only */
@@ -31,6 +32,9 @@ class ResourcesSpec extends Specification with unfiltered.specs2.netty.Served {
      }
      "respond with NotFound (404) for requests for non-existant files" in {
        httpx(host / "foo.bar").code must be_==(404)
+     }
+     "respond with Forbidden (403) for directory traversal requests" in {
+       httpx(HttpUrl.parse(s"http://localhost:$port///etc/passwd")).code must be_==(403)
      }
      "respond with Forbidden (403) for requests for a directory by default" in {
        httpx(host).code must be_==(403)


### PR DESCRIPTION
Using 0.10.2 it was noted that a path traversal vulnerability exists in the unfiltered.netty.Resources intent. This is a critical vulnerability which may render unwanted exposure to files.

No further change has been found on newer versions and a change suggested for 0.10.2

A simple example is to call `http://localhost//etc/passwd/` (note the double slash on the path)

This was found by running a fuzzing tool such as `wfuzz` on a server implementation we are running.

Further to this an Injection scan was run eg

`docker run  -v $(pwd)/wordlist:/wordlist/ ghcr.io/xmendez/wfuzz wfuzz -Z --hc 404 -z file --zP fn=wordlist/Injections/All_attack.txt http://host.docker.internal:8090/FUZZ`

which exposed a number of 500 errors, polluting stack traces on the server, primarily caused by issues such as

```java.net.URISyntaxException: Illegal character in path at index 91...
java.net.URI$Parser.fail(URI.java:2848)
	at java.net.URI$Parser.checkChars(URI.java:3021)
	at java.net.URI$Parser.parseHierarchical(URI.java:3105)
	at java.net.URI$Parser.parse(URI.java:3053)
	at java.net.URI.<init>(URI.java:588)
	at java.net.URL.toURI(URL.java:946)
	at unfiltered.netty.resources.Resolve$$anonfun$2.$anonfun$applyOrElse$2(resolvers.scala:18)
	at unfiltered.netty.resources.Resolve$.apply(resolvers.scala:24)
	at unfiltered.netty.Resources.$anonfun$safe$1(resources.scala:170)
	at scala.Option.flatMap(Option.scala:271)
	at unfiltered.netty.Resources.unfiltered$netty$Resources$$safe(resources.scala:162)
```

A test confirms this by exposing /etc/passwd, returning a 200 if not patched

A fix has been created in the `safe` function which handles a basic traversal issue

- fixes any `//` requests which can expose a directory traversal problem
- check for MalformedURLExceptions when attempting to resolve
- ensures that no breakout of the base directory is performed even if `../` is handled previously, this may be realised by escaping techniques

Notably with these fixes, all responses to the `wfuzz` tool were 404 which is to be expected